### PR TITLE
Dependencies: Update `pre-commit` requirement `mypy==0.981`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Source = 'https://github.com/sphuber/aiida-shell'
 
 [project.optional-dependencies]
 pre-commit = [
-    'mypy==0.950',
+    'mypy==0.981',
     'pre-commit~=2.17',
     'pylint==2.13.7',
     'pylint-aiida~=0.1.1',


### PR DESCRIPTION
This includes a bugfix that was affecting the pre-commit in CI where `mypy` would fail with the error:

    Positional-only parameters are only supported in Python 3.8 and greater

This affected code in `numpy`.