### PR TITLE
`ShellJob`: Add the `ERROR_STDERR_NOT_EMPTY` exit code

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -59,6 +59,11 @@ class ShellJob(CalcJob):
         spec.exit_code(
             400, 'ERROR_COMMAND_FAILED', message='The command exited with a non-zero status: {status} {stderr}.'
         )
+        spec.exit_code(
+            410,
+            'ERROR_STDERR_NOT_EMPTY',
+            message='The command exited with a zero status but the stderr was not empty.'
+        )
 
     @classmethod
     def validate_nodes(cls, value: t.Mapping[str, Data], _) -> str | None:

--- a/src/aiida_shell/parsers/shell.py
+++ b/src/aiida_shell/parsers/shell.py
@@ -62,8 +62,9 @@ class ShellParser(Parser):
             with (dirpath / ShellJob.FILENAME_STDERR).open(mode='rb') as handle:
                 node_stderr = SinglefileData(handle, filename=ShellJob.FILENAME_STDERR)
         except FileNotFoundError:
-            pass
+            stderr = ''
         else:
+            stderr = node_stderr.get_content()
             self.out(ShellJob.FILENAME_STDERR, node_stderr)
 
         try:
@@ -82,7 +83,10 @@ class ShellParser(Parser):
             return self.exit_codes.ERROR_OUTPUT_STATUS_INVALID
 
         if exit_status != 0:
-            return self.exit_codes.ERROR_COMMAND_FAILED.format(status=exit_status, stderr=node_stderr.get_content())
+            return self.exit_codes.ERROR_COMMAND_FAILED.format(status=exit_status, stderr=stderr)
+
+        if stderr:
+            return self.exit_codes.ERROR_STDERR_NOT_EMPTY
 
         return ExitCode()
 

--- a/tests/parsers/test_shell.py
+++ b/tests/parsers/test_shell.py
@@ -76,6 +76,18 @@ def test_status_invalid(parse_calc_job, create_retrieved_temporary):
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_STATUS_INVALID.status
 
 
+def test_stderr(parse_calc_job, create_retrieved_temporary):
+    """Test parser returns ``ERROR_STDERR_NOT_EMPTY`` if the command status is 0 but the stderr file is not empty."""
+    content_stderr = 'some error message'
+    retrieved_temporary = create_retrieved_temporary({ShellJob.FILENAME_STDERR: content_stderr})
+    _, results, calcfunction = parse_calc_job(filepath_retrieved_temporary=retrieved_temporary)
+
+    assert not calcfunction.is_finished_ok, calcfunction.exit_status
+    assert calcfunction.exit_status == ShellJob.exit_codes.ERROR_STDERR_NOT_EMPTY.status
+    assert isinstance(results[ShellJob.FILENAME_STDERR], SinglefileData)
+    assert results[ShellJob.FILENAME_STDERR].get_content() == content_stderr
+
+
 def test_outputs(parse_calc_job, create_retrieved_temporary):
     """Test parsing of the outputs defined by the job."""
     files = {


### PR DESCRIPTION
Fixes #14 

Certain shell commands may fail to properly return a non-zero exit code if the command failed. Currently, these shell job's are marked as finished successfully, which can be misleading. Often, the error will be written to stderr which is a marker for the failure.

Here we add the `ERROR_STDERR_NOT_EMPTY` exit code that is returned by the `ShellParser` if the exit status of the command is zero but the stderr is not empty.