### PR TITLE
`launch_shell_job`: Change log level from warning to info

### DIFF
--- a/src/aiida_shell/engine/launchers/shell_job.py
+++ b/src/aiida_shell/engine/launchers/shell_job.py
@@ -50,7 +50,7 @@ def launch_shell_job(
     try:
         code = load_code(code_label)
     except exceptions.NotExistent:
-        LOGGER.warning('No code exists yet for `%s`, creating it now.', code_label)
+        LOGGER.info('No code exists yet for `%s`, creating it now.', code_label)
         code = Code(  # type: ignore[assignment]
             label=command,
             remote_computer_exec=(computer, executable),
@@ -87,11 +87,11 @@ def prepare_computer(computer: Computer | None = None) -> Computer:
         raise TypeError(f'`metadata.options.computer` should be instance of `Computer` but got: {type(computer)}.')
 
     if computer is None:
-        LOGGER.warning('No computer specified, assuming `localhost`.')
+        LOGGER.info('No computer specified, assuming `localhost`.')
         try:
             computer = load_computer('localhost')
         except exceptions.NotExistent:
-            LOGGER.warning('No `localhost` computer exists yet: creating and configuring the `localhost` computer.')
+            LOGGER.info('No `localhost` computer exists yet: creating and configuring the `localhost` computer.')
             computer = Computer(
                 label='localhost',
                 hostname='localhost',


### PR DESCRIPTION
Fixes #9 

The `launch_shell_job` emits a log message on the warning level if no explicit computer is specified and if the `Code` is created automatically. However, given that warnings are always shown with the default logging configuration of AiiDA and that most users will not explicitly specify a code, as that is the whole point of this convenience wrapper, they will get the warning message every time.

Instead, the log message is now emitted on the info level so it won't be shown by default but can be made visible by changing the log level for the AiiDA logger to `INFO`.