### PR TITLE
`ShellJob`: Customize the `_build_process_label` method

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -90,6 +90,18 @@ class ShellJob(CalcJob):
 
         return None
 
+    def _build_process_label(self) -> str:
+        """Construct the process label that should be set on ``ProcessNode`` instances for this process class.
+
+        Override the base implementation to include the full label of the ``Code`` which provides more useful info to
+        the user, for example when looking at an overview of submitted processes.
+
+        :returns: The process label to use for ``ProcessNode`` instances.
+        """
+        if self.inputs:
+            return f'ShellJob<{self.inputs.code.full_label}>'
+        return super()._build_process_label()
+
     def prepare_for_submission(self, folder: Folder) -> CalcInfo:
         """Prepare the calculation for submission.
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -177,6 +177,15 @@ def test_validate_nodes(generate_calc_job, generate_code, node_cls, message, mon
         generate_calc_job('core.shell', {'code': generate_code(), 'nodes': nodes})
 
 
+def test_build_process_label(generate_calc_job, generate_code):
+    """Test the :meth:`~aiida_shell.calculations.shell_job.ShellJob.build_process_label` method."""
+    computer = 'localhost'
+    executable = '/bin/echo'
+    code = generate_code(executable, computer_label=computer, label='echo')
+    process = generate_calc_job('core.shell', {'code': code}, return_process=True)
+    assert process._build_process_label() == f'ShellJob<{code.full_label}>'  # pylint: disable=protected-access
+
+
 def test_submit_to_daemon(generate_code, submit_and_await):
     """Test submitting a ``ShellJob`` to the daemon."""
     builder = generate_code('echo').get_builder()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def generate_calc_job(tmp_path):
     as well as the ``CalcInfo`` instance that it returned.
     """
 
-    def factory(entry_point_name, inputs=None):
+    def factory(entry_point_name, inputs=None, return_process=False):
         """Create a :class:`aiida.engine.CalcJob` instance with the given inputs."""
         manager = get_manager()
         runner = manager.get_runner()
@@ -59,6 +59,10 @@ def generate_calc_job(tmp_path):
         process = instantiate_process(runner, process_class, **inputs or {})
 
         calc_info = process.prepare_for_submission(Folder(tmp_path))
+
+        if return_process:
+            return process
+
         return tmp_path, calc_info
 
     return factory


### PR DESCRIPTION
Fixes #7 

This method returns the string that is set as the `process_label` attribute on the nodes representing executions of the process class. By default this is the name of the process class, i.e., `ShellJob` in this case. This is not very informative as all `ShellJob` runs, regardless of the shell command it ran, will get the same label.

Here we override the `_build_process_label` to include the full label of the code, which in turn will include the label (typically the name of the shell command) and the name of the computer on which is was run. An example is `ShellJob<echo@localhost>`.