### PR TITLE
`launch_shell_job`: Add the `submit` argument to run over the daemon

### DIFF
--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -175,3 +175,12 @@ def test_validate_nodes(generate_calc_job, generate_code, node_cls, message, mon
 
     with pytest.raises(ValueError, match=message):
         generate_calc_job('core.shell', {'code': generate_code(), 'nodes': nodes})
+
+
+def test_submit_to_daemon(generate_code, submit_and_await):
+    """Test submitting a ``ShellJob`` to the daemon."""
+    builder = generate_code('echo').get_builder()
+    builder.arguments = ['testing']
+    node = submit_and_await(builder)
+    assert node.is_finished_ok, node.process_state
+    assert node.outputs.stdout.get_content().strip() == 'testing'

--- a/tests/engine/launchers/test_shell_job.py
+++ b/tests/engine/launchers/test_shell_job.py
@@ -114,3 +114,12 @@ def test_arguments_files():
 
     assert node.is_finished_ok
     assert results['stdout'].get_content().strip() == content.split('\n', maxsplit=1)[0]
+
+
+def test_submit(submit_and_await):
+    """Test the ``submit`` argument."""
+    node = launch_shell_job('date', submit=True)
+    submit_and_await(node)
+    assert node.is_finished_ok
+    assert isinstance(node.outputs.stdout, SinglefileData)
+    assert node.outputs.stdout.get_content()


### PR DESCRIPTION
Fixes #2 

The `submit` argument takes a boolean and when set to `True` the shell job is sent to the daemon instead of run by the current interpreter. If the shell jobs are independent, this allows them to be run in parallel by the daemon workers.