### PR TITLE
Dependencies: Update requirement `aiida-core~=2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core @ git+https://github.com/aiidateam/aiida-core.git@main',
+    'aiida-core~=2.1',
 ]
 
 [project.urls]


### PR DESCRIPTION
The functionality we were relying on has now been officially released with `aiida-core==2.1` so we can use that as the minimum requirement instead of installing from the repository.