### PR TITLE
`ShellJob`: Use `SinglefileData.filename` before falling back on key

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,24 @@ which prints `string astring b`.
 The keys in the `nodes` dictionary can only use alphanumeric characters and underscores.
 The keys will be used as the link label of the file in the provenance graph, and as the filename in the temporary directory in which the shell command will be executed.
 Certain commands may require specific filenames, for example including a file extension, e.g., `filename.txt`, but this cannot be used in the `nodes` arguments.
-To specify explicit filenames that should be used in the running directory, that are different from the keys in the `nodes` argument, use the `filenames` argument:
+To specify explicit filenames that should be used in the running directory, make sure that the `filename` of the `SinglefileData` node is defined.
+If the `SinglefileData.filename` was explicitly set when creating the node, that is the filename used to write the input file to the working directory:
+```python
+from io import StringIO
+from aiida.orm import SinglefileData
+from aiida_shell import launch_shell_job
+results, node = launch_shell_job(
+    'cat',
+    arguments=['{file_a}'],
+    nodes={
+        'file_a': SinglefileData(StringIO('string a'), filename='filename.txt'),
+    }
+)
+print(results['stdout'].get_content())
+```
+which prints `string a`.
+
+If the filename of the `SinglefileData` cannot be controlled, alternatively explicit filenames can be defined using the `filenames` argument:
 ```python
 from io import StringIO
 from aiida.orm import SinglefileData
@@ -86,6 +103,7 @@ results, node = launch_shell_job(
 print(results['stdout'].get_content())
 ```
 which prints `string a`.
+Filenames specified in the `filenames` input will override the filename of the `SinglefileData` nodes.
 
 The output filename can be anything except for `stdout`, `stderr` and `status`, which are reserved filenames.
 

--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -192,7 +192,7 @@ class ShellJob(CalcJob):
             node = nodes[placeholder]
 
             if isinstance(node, SinglefileData):
-                filename = self.write_single_file_data(dirpath, nodes[placeholder], placeholder, filenames)
+                filename = self.write_single_file_data(dirpath, node, placeholder, filenames)
                 argument_interpolated = argument.format(**{placeholder: filename})
             else:
                 argument_interpolated = argument.format(**{placeholder: str(node.value)})
@@ -216,7 +216,8 @@ class ShellJob(CalcJob):
         :param filenames: Mapping that can provide explicit filenames for the given key.
         :returns: The relative filename used to write the content to ``dirpath``.
         """
-        filename = filenames.get(key, key)
+        default_filename = node.filename if node.filename and node.filename != SinglefileData.DEFAULT_FILENAME else key
+        filename = filenames.get(key, default_filename)
         filepath = dirpath / filename
 
         with node.open(mode='rb') as handle:

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -61,16 +61,23 @@ def test_nodes_base_types(generate_calc_job, generate_code):
     assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
 
 
-def test_filenames(generate_calc_job, generate_code):
-    """Test the ``filenames`` input."""
+def test_nodes_single_file_data_filename(generate_calc_job, generate_code):
+    """Test the selection rules for the filename used for ``SinglefileData`` nodes.
+
+    The filename is determined in the following order:
+
+     * Explicitly defined in ``filenames``,
+     * The ``filename`` property of the ``SinglefileData`` node,
+     * The key of the node in the ``nodes`` inputs dictionary.
+    """
     inputs = {
         'code': generate_code(),
         'nodes': {
-            'xa': SinglefileData(io.StringIO('content')),
+            'xa': SinglefileData(io.StringIO('content'), filename='single_file_a'),
             'xb': SinglefileData(io.StringIO('content')),
+            'xc': SinglefileData(io.StringIO('content')),
         },
         'filenames': {
-            'xa': 'filename_a',
             'xb': 'filename_b',
         }
     }
@@ -80,7 +87,7 @@ def test_filenames(generate_calc_job, generate_code):
     assert code_info.cmdline_params == []
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
     assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
-    assert sorted([p.name for p in dirpath.iterdir()]) == ['filename_a', 'filename_b']
+    assert sorted([p.name for p in dirpath.iterdir()]) == ['filename_b', 'single_file_a', 'xc']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #24 

So far the logic for determining the filename used to write the content of the inputs `nodes` in the running directory to, was to first look if an explicit filename was defined in the `filenames` input and otherwise to fallback to the `key` of the node within the `nodes` dictionary.

Here we change the code to use the `filename` of the `SinglefileData` before falling back to the key, if and only if the `filename` of the node is defined and not `SinglefileData.DEFAULT_FILENAME`. This last exception is important because if a `SinglefileData` node is constructed without explicit filename, that value is used, and with this new fule any `SinglefileData` nodes that were created without explicit filename will end up overwriting each other.