### PR TITLE
`ShellJob`: Add `filename_stdin` input to redirect file through stdin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
         files: >-
             (?x)^(
                 src/.*py|
+                tests/*.py|
             )$
 
     -   id: pylint

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ which prints `1.0 2 string`.
 This example is of course contrived, but when combining it with other components of AiiDA, which typically return outputs of these form, they can be used directly as inputs for `launch_shell_job` without having to convert the values.
 This ensures that provenance is kept.
 
+### Redirecting input file through stdin
+Certain shell commands require input to be passed through the stdin file descriptor.
+This is normally accomplished as follows:
+```bash
+cat < input.txt
+```
+To reproduce this behaviour, the file that should be redirected through stdin can be defined using the `metadata.option.filename_stdin` input:
+```python
+from io import StringIO
+from aiida.orm import SinglefileData
+from aiida_shell import launch_shell_job
+results, node = launch_shell_job(
+    'cat',
+    nodes={
+        'input': SinglefileData(StringIO('string a'))
+    },
+    metadata={'options': {'filename_stdin': 'input'}}
+)
+print(results['stdout'].get_content())
+```
+which prints `string a`.
+
 ### Defining output files
 When the shell command is executed, AiiDA captures by default the content written to the stdout and stderr file descriptors.
 The content is wrapped in a `SinglefileData` node and attached to the `ShellJob` with the `stdout` and `stderr` link labels, respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pre-commit = [
 tests = [
     'pgtest~=1.3,>=1.3.1',
     'pytest~=6.2',
+    'pytest-regressions',
 ]
 
 [project.entry-points.'aiida.calculations']

--- a/tests/calculations/test_shell/test_filename_stdin.txt
+++ b/tests/calculations/test_shell/test_filename_stdin.txt
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec > _scheduler-stdout.txt
+exec 2> _scheduler-stderr.txt
+
+
+'/usr/bin/cat' < 'filename' > 'stdout' 2> 'stderr'
+
+echo $? > status


### PR DESCRIPTION
Fixes #25 

Certain codes require the input file to be passed in through the stdin file descriptor. Currently there is no way to do this. One could try to specify the `arguments` input as `['<', '{input_file}']` but the redirection argument would be quoted and read as a literal argument and so wouldn't work.

The `metadata.options.filename_stdin` input is added. When specified, the filename is defined as the `stdin_name` attribute on the `CodeInfo` instance prepared by `prepare_for_submission`. This will cause the scheduler plugin to create the command execution line:

    executable < stdin_name

If `filename_stdin` is specified, the filename should be removed from the `cmdline_arguments` attribute set on the `CodeInfo`, because otherwise, the filename would be written twice on the command execution line:

    executable stdin_name < stdin_name