### PR TITLE
`ShellJob`: Raise when `<` or `>` are specified in `arguments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ print(results['stdout'].get_content())
 ```
 which prints `string a`.
 
+N.B.: one might be tempted to simply define the `arguments` as `['<', '{input}']`, but this won't work as the `<` symbol will be quoted and will be read as a literal command line argument, not as the redirection symbol.
+This is why passing the `<` in the `arguments` input will result in a validation error.
+
 ### Defining output files
 When the shell command is executed, AiiDA captures by default the content written to the stdout and stderr file descriptors.
 The content is wrapped in a `SinglefileData` node and attached to the `ShellJob` with the `stdout` and `stderr` link labels, respectively.

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -207,6 +207,20 @@ def test_validate_nodes(generate_calc_job, generate_code, node_cls, message, mon
         generate_calc_job('core.shell', {'code': generate_code(), 'nodes': nodes})
 
 
+@pytest.mark.parametrize(
+    'arguments, message', (
+        (['string', 1], r'.*all elements of the `arguments` input should be strings'),
+        (['string', {input}], r'.*all elements of the `arguments` input should be strings'),
+        (['<', '{filename}'], r'`<` cannot be specified in the `arguments`.*'),
+        (['{filename}', '>'], r'the symbol `>` cannot be specified in the `arguments`.*'),
+    )
+)
+def test_validate_arguments(generate_calc_job, generate_code, arguments, message):
+    """Test the validator for the ``arguments`` argument."""
+    with pytest.raises(ValueError, match=message):
+        generate_calc_job('core.shell', {'code': generate_code(), 'arguments': arguments})
+
+
 def test_build_process_label(generate_calc_job, generate_code):
     """Test the :meth:`~aiida_shell.calculations.shell_job.ShellJob.build_process_label` method."""
     computer = 'localhost'


### PR DESCRIPTION
Fixes #23 

Stdout redirection is performed automatically by the `ShellJob` and the `metadata.options.filename_stdin` input should be used to redirect a particular file to stdin. Attempting to perform these redirections "manually" through the `arguments` input will fail as the symbols will be quoted and so interpreted as a literal command line argument.

To prevent users making this mistake, a validator is added for the `arguments` input that validates that all elements are strings and that the reserved symbols are not defined.