### PR TITLE
`ShellJob`: Automatically create parent directories in `filenames`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ print(results['stdout'].get_content())
 ```
 which prints `string a`.
 Filenames specified in the `filenames` input will override the filename of the `SinglefileData` nodes.
+Any parent directories in the filepath, for example `some/nested/path` in the filename `some/nested/path/file.txt`, will be automatically created.
 
 The output filename can be anything except for `stdout`, `stderr` and `status`, which are reserved filenames.
 

--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -255,6 +255,8 @@ class ShellJob(CalcJob):
         filename = filenames.get(key, default_filename)
         filepath = dirpath / filename
 
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
         with node.open(mode='rb') as handle:
             filepath.write_bytes(handle.read())
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -132,16 +132,21 @@ def test_arguments_files(generate_calc_job, generate_code):
 
 
 def test_arguments_files_filenames(generate_calc_job, generate_code):
-    """Test the ``arguments`` with placeholders for files and explicit filenames."""
+    """Test the ``arguments`` with placeholders for files and explicit filenames.
+
+    Nested directories should be created automatically.
+    """
     arguments = List(['{file_a}'])
     inputs = {
         'code': generate_code(),
         'arguments': arguments,
         'nodes': {
-            'file_a': SinglefileData(io.StringIO('content'))
+            'file_a': SinglefileData(io.StringIO('content')),
+            'file_b': SinglefileData(io.StringIO('content')),
         },
         'filenames': {
-            'file_a': 'custom_filename'
+            'file_a': 'custom_filename',
+            'file_b': 'nested/custom_filename',
         }
     }
     _, calc_info = generate_calc_job('core.shell', inputs)


### PR DESCRIPTION
If a nested filepath was passed in the `filenames` input namespace, the code would except with a `FileNotFoundError` if any of the parent directories did not exist. The `ShellJob.write_single_file_data` method is updated to always create the parent directories of a filepath before attempting to write to it.