### PR TITLE
Dependencies: Update pre-commit requirement `isort==5.12.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flynt
 
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
     -   id: isort
 


### PR DESCRIPTION
Older versions were breaking due to a release of `poetry-core` causing our pre-commit job in the CI to fail. For details, see: https://github.com/PyCQA/isort/issues/2077