### PR TITLE
`launch_shell_job`: Accept `AbstractCode` for `command` argument

### DIFF
--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -279,6 +279,23 @@ To specify what computer to use for a shell command, pass it as an option to the
 Here you can use ``aiida.orm.load_computer`` to load the ``Computer`` instance from its label, PK or UUID.
 
 
+Defining a pre-configured code
+==============================
+
+The first argument, ``command``, of ``launch_shell_job`` takes the name of the command to be run as a string.
+Under the hood, this is automatically converted into an :class:`~aiida.orm.nodes.data.code.abstract.AbstractCode`.
+The ``command`` argument also accepts a pre-configured code instance directly:
+
+.. code-block:: python
+
+    from aiida.orm import load_code
+    from aiida_shell import launch_shell_job
+    code = load_code('date@localhost')
+    results, node = launch_shell_job(code)
+
+This approach can be used as an alternative to the previous example where the target computer is specified through the `metadata` argument.
+
+
 Running many shell jobs in parallel
 ===================================
 

--- a/tests/engine/launchers/test_shell_job.py
+++ b/tests/engine/launchers/test_shell_job.py
@@ -5,7 +5,7 @@ import io
 import json
 import pathlib
 
-from aiida.orm import Float, Int, SinglefileData, Str
+from aiida.orm import AbstractCode, Float, Int, SinglefileData, Str
 import pytest
 
 from aiida_shell.calculations.shell import ShellJob
@@ -34,6 +34,21 @@ def test_default():
     assert node.is_finished_ok
     assert isinstance(results['stdout'], SinglefileData)
     assert results['stdout'].get_content()
+
+
+def test_command(generate_code):
+    """Test the ``command`` argument accepts a pre-configured code instance."""
+    code = generate_code()
+    assert isinstance(code, AbstractCode)
+
+    _, node = launch_shell_job(code)
+    assert node.is_finished_ok
+
+
+def test_command_invalid():
+    """Test the ``command`` argument raises a ``TypeError`` if anything but a ``str`` or ``AbstractCode`` is passed."""
+    with pytest.raises(TypeError, match=r'Got object of type .*, expecting .*'):
+        launch_shell_job(None)  # type: ignore[arg-type]
 
 
 def test_arguments():


### PR DESCRIPTION
This can be useful if the user already has a pre-configured code which specifies for example a required remote computer or the pre- and append text attributes. If the `command` is not a string, nor an `AbstractCode` a `TypeError` is raised.