### PR TITLE
`launch_shell_job`: Fix bug in `submit=True` when used within work chain

### DIFF
--- a/src/aiida_shell/engine/launchers/shell_job.py
+++ b/src/aiida_shell/engine/launchers/shell_job.py
@@ -9,7 +9,7 @@ import tempfile
 import typing as t
 
 from aiida.common import exceptions, lang
-from aiida.engine import launch
+from aiida.engine import Process, WorkChain, launch
 from aiida.orm import AbstractCode, Computer, Data, ProcessNode, SinglefileData, load_code, load_computer
 from aiida.parsers import Parser
 
@@ -75,6 +75,9 @@ def launch_shell_job(  # pylint: disable=too-many-arguments
     }
 
     if submit:
+        current_process = Process.current()
+        if current_process is not None and isinstance(current_process, WorkChain):
+            return {}, current_process.submit(ShellJob, **inputs)
         return {}, launch.submit(ShellJob, **inputs)
 
     results, node = launch.run_get_node(ShellJob, **inputs)


### PR DESCRIPTION
Fixes #37 

When the `submit` argument of `launch_shell_job` is set to `True` the job is submitted to the daemon using `aiida.engine.launch.submit`. However, when this is executed within the context of a work chain, this raises an error as `WorkChain.submit` should be used in this case instead of the global function.

The `launch_shell_job` function is updated to check whether it is called in the scope of a `WorkChain` by using `aiida.engine.Process.current()`. If the case, the `WorkChain.submit` is used instead of the global launch function.