### PR TITLE
`ShellJob`: Remove `tot_num_mpiprocs` from `resources` default

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -57,7 +57,7 @@ class ShellJob(CalcJob):
 
         options = spec.inputs['metadata']['options']  # type: ignore[index]
         options['parser_name'].default = 'core.shell'  # type: ignore[index]
-        options['resources'].default = {'num_machines': 1, 'tot_num_mpiprocs': 1}  # type: ignore[index]
+        options['resources'].default = {'num_machines': 1}  # type: ignore[index]
 
         spec.outputs.dynamic = True
 

--- a/src/aiida_shell/engine/launchers/shell_job.py
+++ b/src/aiida_shell/engine/launchers/shell_job.py
@@ -149,6 +149,7 @@ def prepare_computer(computer: Computer | None = None) -> Computer:
             ).store()
             computer.configure(safe_interval=0.)
             computer.set_minimum_job_poll_interval(0.)
+            computer.set_default_mpiprocs_per_machine(1)
 
     default_user = computer.backend.default_user
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,7 @@ def generate_computer():
 
         computer.configure(safe_interval=0.)
         computer.set_minimum_job_poll_interval(0.)
+        computer.set_default_mpiprocs_per_machine(1)
 
         return computer
 


### PR DESCRIPTION
The `ShellJob` specified `tot_num_mpiprocs: 1` in the `resources` option input. This is problematic as it would always override the attribute `default_mpiprocs_per_machine` of the computer. This made it essentially impossible for a user to specify a pre-configured computer with a number of MPI processes per machine other than 1.

By removing the default, this does now mean that the `tot_num_mpiprocs` or the `mpiprocs_per_machine` key in the resources have to be set or the validation of the resources by the scheduler plugin may fail. It is not desirable that the user has to specify this manually, so the `localhost` that is automatically generated by `prepare_computer` when going through `launch_shell_job` has `default_mpiprocs_per_machine` set to 1. The same goes for the `localhost` computer used in the unit tests.