### PR TITLE
`ShellJob`: Add the optional `redirect_stderr` input

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.11'
+
 python:
-    version: 3.8
     install:
     -   method: pip
         path: .

--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -175,6 +175,33 @@ N.B.: one might be tempted to simply define the ``arguments`` as ``'< {input}'``
 This is why passing the ``<`` in the ``arguments`` input will result in a validation error.
 
 
+Redirecting stderr to the stdout file
+=====================================
+
+A common practice when running shell commands is to redirect the content, written to the stderr file descriptor, to stdout.
+This is normally accomplished as follows:
+
+.. code-block:: bash
+
+    date > stdout 2>&1
+
+To reproduce this behaviour, set the ``metadata.option.redirect_stderr`` input to ``True``:
+
+.. code-block:: python
+
+    from aiida_shell import launch_shell_job
+    results, node = launch_shell_job(
+        'date',
+        metadata={'options': {'redirect_stderr': True}}
+    )
+
+If the option is not specified, or set to ``False``, the stderr will be redirected to the file named ``stderr``, as follows:
+
+.. code-block:: bash
+
+    date > stdout 2> stderr
+
+
 Defining outputs
 ================
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -178,6 +178,23 @@ def test_filename_stdin(generate_calc_job, generate_code, file_regression):
     file_regression.check((pathlib.Path(tmp_path) / filename_submit_script).read_text(), encoding='utf-8')
 
 
+@pytest.mark.parametrize('redirect_stderr', (True, False, None))
+def test_redirect_stderr(generate_calc_job, generate_code, redirect_stderr):
+    """Test the ``metadata.options.redirect_stderr`` input."""
+    inputs = {'code': generate_code('cat'), 'metadata': {'options': {}}}
+
+    if redirect_stderr is not None:
+        inputs['metadata']['options']['redirect_stderr'] = redirect_stderr
+
+    _, calc_info = generate_calc_job('core.shell', inputs, presubmit=True)
+    code_info = calc_info.codes_info[0]
+
+    if redirect_stderr is True:
+        assert code_info.join_files == redirect_stderr
+    else:
+        assert code_info.stderr_name == ShellJob.FILENAME_STDERR
+
+
 @pytest.mark.parametrize(
     'outputs, message', (
         ([ShellJob.FILENAME_STATUS], r'`.*` is a reserved output filename and cannot be used in `outputs`.'),


### PR DESCRIPTION
This metadata input, if set to `True`, will set `CodeInfo.join_files` to `True` instead of defining `CodeInfo.stderr_name`. This will cause the submission script to look like:

    date > stdout 2>&1

instead of the default:

    date > stdout 2> stderr

meaning that content written to the stderr file descriptor will be redirected to the stdout file.