### PR TITLE
Docs: Update Python version on RTD to 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.11'
+
 python:
-    version: 3.8
     install:
     -   method: pip
         path: .


### PR DESCRIPTION
A recent release of `urllib3` was breaking the build, see: https://github.com/urllib3/urllib3/issues/2168
The problem does not apply to more recent versions of Python.