### PR TITLE
`ShellJob`: Do not copy contents of `nodes` to repository

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -229,6 +229,7 @@ class ShellJob(CalcJob):
         calc_info.codes_info = [code_info]
         calc_info.append_text = f'echo $? > {self.FILENAME_STATUS}'
         calc_info.retrieve_temporary_list = retrieve_list
+        calc_info.provenance_exclude_list = [p.name for p in dirpath.iterdir()]
 
         return calc_info
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -41,6 +41,7 @@ def test_nodes_single_file_data(generate_calc_job, generate_code):
     assert code_info.cmdline_params == []
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
     assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert sorted(calc_info.provenance_exclude_list) == ['xa', 'xb']
     assert sorted([p.name for p in dirpath.iterdir()]) == ['xa', 'xb']
 
 
@@ -72,6 +73,7 @@ def test_nodes_folder_data(generate_calc_job, generate_code, tmp_path):
     assert code_info.cmdline_params == ['nested', 'sub']
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
     assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert sorted(calc_info.provenance_exclude_list) == ['dir', 'file_a.txt', 'file_b.txt', 'sub']
     assert sorted([p.name for p in dirpath.iterdir()]) == ['dir', 'file_a.txt', 'file_b.txt', 'sub']
     assert sorted([p.name for p in (dirpath / 'dir').iterdir()]) == ['file_a.txt', 'file_b.txt']
     assert sorted([p.name for p in (dirpath / 'sub').iterdir()]) == ['dir', 'file_a.txt', 'file_b.txt']


### PR DESCRIPTION
The contents of all `SinglefileData` and `FolderData` nodes in the `nodes` input namespace are written to the sandbox folder during the `prepare_for_submission`. The contents of this folder are also copied to the repository of the `CalcJobNode` representing the `ShellJob` execution.

This is undesirable, however, since the content is essentially duplicated in the data storage. The fact that all this content is already indirectly attached to the `CalcJobNode` through the input links of the relevant input node, it is not necessary to store it once again.

Therefore, all content written to the `folder` sandbox are added to the `provenance_exclude_list` which ensures that the engine does not copy the contents to the `CalcJobNode` repository.