### PR TITLE
`ShellJob`: Allow entry point strings for the `parser` input

### DIFF
--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -581,3 +581,10 @@ which prints ``some output``.
         print(results['json'].get_dict())
 
     which prints ``{'a': 1}``.
+
+.. tip::
+
+    If you find yourself reusing the same parser often, you can also register it with an entry point and use that for the ``parser`` input.
+    See the `AiiDA documentation <https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/plugins_develop.html?highlight=entry%20point#registering-plugins-through-entry-points>`_ for details on how to register entry points.
+    For example, if the parser is registered with the name ``some.parser`` in the group ``aiida.parsers``, the ``parser`` input will accept ``aiida.parsers:some.parser``.
+    The entry point will automatically be validated and wrapped in a :class:`aiida_shell.data.entry_point.EntryPointData`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tests = [
 
 [project.entry-points.'aiida.data']
 'core.code.installed.shell' = 'aiida_shell.data.code:ShellCode'
+'core.entry_point' = 'aiida_shell.data.entry_point:EntryPointData'
 'core.pickled' = 'aiida_shell.data.pickled:PickledData'
 
 [project.entry-points.'aiida.parsers']

--- a/src/aiida_shell/data/__init__.py
+++ b/src/aiida_shell/data/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.data`."""
 from .code import ShellCode
+from .entry_point import EntryPointData
 from .pickled import PickledData
 
-__all__ = ('PickledData', 'ShellCode')
+__all__ = ('EntryPointData', 'PickledData', 'ShellCode')

--- a/src/aiida_shell/data/entry_point.py
+++ b/src/aiida_shell/data/entry_point.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Data plugin to store a reference to an entry point."""
+from __future__ import annotations
+
+import typing as t
+
+from aiida.common.exceptions import EntryPointError
+from aiida.common.lang import type_check
+from aiida.common.log import AIIDA_LOGGER
+from aiida.orm import Data
+from aiida.plugins.entry_point import get_entry_point
+from aiida.plugins.utils import PluginVersionProvider
+from importlib_metadata import EntryPoint
+
+LOGGER = AIIDA_LOGGER.getChild('entry_point')
+VERSION_PROVIDER = PluginVersionProvider()
+
+
+class EntryPointData(Data):
+    """Data plugin to store a reference to an entry point."""
+
+    KEY_ATTRIBUTES_NAME: str = 'name'
+    """Attribute key that stores the ``name`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_GROUP: str = 'group'
+    """Attribute key that stores the ``group`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_VALUE: str = 'value'
+    """Attribute key that stores the ``value`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_MODULE: str = 'module'
+    """Attribute key that stores the ``module`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_ATTR: str = 'attr'
+    """Attribute key that stores the ``attr`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_EXTRAS: str = 'extras'
+    """Attribute key that stores the ``extras`` attribute of the wrapped entry point."""
+
+    KEY_ATTRIBUTES_VERSION: str = 'version'
+    """Attribute key that stores the version of the package that provided the entry point, if available."""
+
+    def __init__(
+        self, *, entry_point: EntryPoint | None = None, name: str | None = None, group: str | None = None, **kwargs
+    ):
+        """Construct a new instance.
+
+        :raises TypeError: If the ``entry_point`` is provided and is not an instance of ``EntryPoint``.
+        :raises ValueError: If the ``name`` and ``group`` cannot be resolved to an entry point that can be loaded.
+        :raises ValueError: If the ``entry_point`` is inconsistent, i.e., its ``name`` and ``group`` do not correspond
+            to an existing entry point or it corresponds to a different entry point.
+        """
+        super().__init__(**kwargs)
+
+        if entry_point is None and (group is None or name is None):
+            raise ValueError('Define either the `entry_point` directly or the `group` and `name`.')
+
+        if entry_point:
+            type_check(entry_point, EntryPoint)
+
+        if not entry_point:
+            assert group is not None and name is not None
+            try:
+                entry_point = get_entry_point(group, name)
+            except EntryPointError as exception:
+                raise ValueError(f'entry point with group `{group}` and name `{name}` does not exist.') from exception
+
+        try:
+            loaded = entry_point.load()
+        except ModuleNotFoundError as exception:
+            raise ValueError(f'entry point `{entry_point}` could not be loaded.') from exception
+
+        try:
+            reloaded = get_entry_point(entry_point.group, entry_point.name).load()
+        except EntryPointError as exception:
+            raise ValueError(
+                f'Inconsistent entry point: the `name` and `group` of {entry_point} do not match any registered '
+                'entry point.'
+            ) from exception
+
+        if loaded != reloaded:
+            raise ValueError(
+                f'Inconsistent entry point: the `name` and `group` of {entry_point} point to {reloaded} which does not '
+                f'match the value `{entry_point.value}` of the specified entry point.'
+            )
+
+        keys = (
+            self.KEY_ATTRIBUTES_NAME, self.KEY_ATTRIBUTES_GROUP, self.KEY_ATTRIBUTES_VALUE, self.KEY_ATTRIBUTES_MODULE,
+            self.KEY_ATTRIBUTES_ATTR, self.KEY_ATTRIBUTES_EXTRAS
+        )
+        attributes = {key: getattr(entry_point, key) for key in keys}
+        attributes[self.KEY_ATTRIBUTES_VERSION] = VERSION_PROVIDER.get_version_info(loaded)['version'].get('plugin')
+        self.base.attributes.set_many(attributes)
+
+    def load(self) -> t.Any:
+        """Load and return the wrapped entry point.
+
+        :returns: The object that the entry point refers to.
+        :raises EntryPointError: If the entry point does not exist or cannot be loaded.
+        """
+        attributes = self.base.attributes.all
+        entry_point = EntryPoint(
+            name=attributes[self.KEY_ATTRIBUTES_NAME],
+            group=attributes[self.KEY_ATTRIBUTES_GROUP],
+            value=attributes[self.KEY_ATTRIBUTES_VALUE]
+        )
+        return entry_point.load()

--- a/src/aiida_shell/engine/launchers/shell_job.py
+++ b/src/aiida_shell/engine/launchers/shell_job.py
@@ -26,7 +26,7 @@ def launch_shell_job(  # pylint: disable=too-many-arguments
     filenames: dict[str, str] | None = None,
     arguments: list[str] | str | None = None,
     outputs: list[str] | None = None,
-    parser: t.Callable[[Parser, pathlib.Path], dict[str, Data]] | None = None,
+    parser: t.Callable[[Parser, pathlib.Path], dict[str, Data]] | str | None = None,
     metadata: dict[str, t.Any] | None = None,
     submit: bool = False,
 ) -> tuple[dict[str, Data], ProcessNode]:
@@ -41,7 +41,9 @@ def launch_shell_job(  # pylint: disable=too-many-arguments
         arguments can also be specified as a single string. In this case, it will be split into separate parameters
         using ``shlex.split``.
     :param outputs: Optional list of relative filenames that should be captured as outputs.
-    :param parser: Optional callable that can implement custom parsing logic of produced output files.
+    :param parser: Optional callable that can implement custom parsing logic of produced output files. Alternatively,
+        a complete entry point, i.e. a string of the form ``{entry_point_group}:{entry_point_name}`` pointing to such a
+        callable.
     :param metadata: Optional dictionary of metadata inputs to be passed to the ``ShellJob``.
     :param submit: Boolean, if ``True`` will submit the job to the daemon instead of running in current interpreter.
     :raises TypeError: If the value specified for ``metadata.options.computer`` is not a ``Computer``.

--- a/tests/data/test_entry_point.py
+++ b/tests/data/test_entry_point.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida_shell.data.entry_point` module."""
+from aiida.orm import load_node
+from aiida.plugins.entry_point import get_entry_point
+from importlib_metadata import EntryPoint
+import pytest
+
+from aiida_shell.data.entry_point import EntryPointData
+
+InvalidEntryPoint = EntryPoint('b', 'a', group='c')
+InconsistentEntryPoint = EntryPoint('b', 'aiida_shell.data.pickled:PickledData', group='c')
+DifferentEntryPoint = EntryPoint('core.entry_point', 'aiida_shell.data.pickled:PickledData', group='aiida.data')
+
+
+@pytest.fixture
+def entry_point():
+    """Return a valid entry point."""
+    return get_entry_point(group='aiida.data', name='core.entry_point')
+
+
+def test_constructor(entry_point):
+    """Test the constructor of :class:`~aiida_shell.data.entry_point.EntryPointData`."""
+    node = EntryPointData(entry_point=entry_point)
+    assert isinstance(node, EntryPointData)
+
+    node = EntryPointData(group=entry_point.group, name=entry_point.name)
+    assert isinstance(node, EntryPointData)
+
+
+@pytest.mark.parametrize(
+    'kwargs, exception, matches', (
+        ({}, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
+        ({
+            'group': 'some.group'
+        }, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
+        ({
+            'name': 'some.name'
+        }, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
+        ({
+            'entry_point': 'invalid_type'
+        }, TypeError, r'Got object of type .*, expecting .*'),
+        ({
+            'group': 'a',
+            'name': 'a'
+        }, ValueError, r'entry point with group `a` and name `a` does not exist.'),
+        ({
+            'entry_point': InvalidEntryPoint
+        }, ValueError, r'entry point .* could not be loaded.'),
+        ({
+            'entry_point': InconsistentEntryPoint
+        }, ValueError, r'Inconsistent.*: the `name` and `group` of .* do not'),
+        ({
+            'entry_point': DifferentEntryPoint
+        }, ValueError, r'Inconsistent.*: the `name` and `group` of .* point'),
+    )
+)
+def test_constructor_invalid(kwargs, exception, matches):
+    """Test the constructor of :class:`~aiida_shell.data.entry_point.EntryPointData`."""
+    with pytest.raises(exception, match=matches):
+        EntryPointData(**kwargs)
+
+
+def test_load():
+    """Test :meth:`~aiida_shell.data.entry_point.EntryPointData.load`."""
+    node = EntryPointData(group='aiida.data', name='core.entry_point')
+    assert node.load() == EntryPointData
+    print(node.base.attributes.all)
+
+    node.store()
+    assert node.load() == EntryPointData
+
+    loaded = load_node(node.pk)
+    assert loaded.load() == EntryPointData
+
+
+def test_version():
+    """Test that the package version of the wrapped entry point is stored in the attributes."""
+    from aiida_shell import __version__
+    node = EntryPointData(group='aiida.data', name='core.entry_point')
+    assert node.base.attributes.get(EntryPointData.KEY_ATTRIBUTES_VERSION) == __version__


### PR DESCRIPTION
Although allowing to pass a parser function directly to the `parser`
input is convenient during prototyping where the parser can be defined
and used inline, at some point, parsers may become stable and reusable
in multiple places. In these cases, it makes sense to register them with
an entry point and pass that instead.

The `parser` input of the `ShellJob` now also accepts `EntryPointData`
nodes, in addition to `PickledData` nodes. The serializer will
automatically try to detect whether the passed value is a callable or a
string representing a complete entry point.