### PR TITLE
Devops: Migrate to `ruff` and cleanup pre-commit config

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
                 python-version: '3.10'
 
         -   name: Install Python dependencies
-            run: pip install -e .[pre-commit,tests]
+            run: pip install -e .[dev]
 
         -   name: Run pre-commit
             run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
@@ -86,7 +86,7 @@ jobs:
             run: sudo apt update && sudo apt install postgresql
 
         -   name: Install Python dependencies
-            run: pip install -e .[tests]
+            run: pip install -e .[dev]
 
         -   name: Run pytest
             run: pytest -sv tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
                 python-version: '3.10'
 
         -   name: Install Python package and dependencies
-            run: pip install -e .[pre-commit,tests]
+            run: pip install -e .[dev]
 
         -   name: Run pre-commit
             run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
@@ -67,7 +67,7 @@ jobs:
             run: sudo apt update && sudo apt install postgresql
 
         -   name: Install Python package and dependencies
-            run: pip install -e .[tests]
+            run: pip install -e .[dev]
 
         -   name: Run pytest
             env:

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Validate that the version in the tag label matches the version of the package."""
 import argparse
 import ast
@@ -17,8 +16,11 @@ def get_version_from_module(content: str) -> str:
 
     try:
         return next(
-            ast.literal_eval(statement.value) for statement in module.body if isinstance(statement, ast.Assign)
-            for target in statement.targets if isinstance(target, ast.Name) and target.id == '__version__'
+            ast.literal_eval(statement.value)
+            for statement in module.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Name) and target.id == '__version__'
         )
     except StopIteration as exception:
         raise IOError('Unable to find the `__version__` attribute in the module.') from exception

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,34 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.2.0'
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v4.5.0'
     hooks:
-    -   id: double-quote-string-fixer
-    -   id: end-of-file-fixer
-    -   id: fix-encoding-pragma
-    -   id: mixed-line-ending
-    -   id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: double-quote-string-fixer
+      - id: end-of-file-fixer
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
 
--   repo: https://github.com/ikamensh/flynt/
+  - repo: https://github.com/ikamensh/flynt/
     rev: '0.76'
     hooks:
-    -   id: flynt
+      - id: flynt
 
--   repo: https://github.com/pycqa/isort
-    rev: '5.12.0'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.3'
     hooks:
-    -   id: isort
+      - id: ruff-format
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.32.0'
+  - repo: local
     hooks:
-    -   id: yapf
-        name: yapf
-        types: [python]
-        args: ['-i']
-        additional_dependencies: ['toml']
-
--   repo: https://github.com/PyCQA/pydocstyle
-    rev: '6.1.1'
-    hooks:
-    -   id: pydocstyle
-        additional_dependencies: ['toml']
-
--   repo: local
-    hooks:
-    -   id: mypy
+      - id: mypy
         name: mypy
         entry: mypy
-        args: [--config-file=pyproject.toml]
         language: python
+        args: [--config-file=pyproject.toml]
         types: [python]
-        require_serial: true
-        pass_filenames: true
-        files: >-
-            (?x)^(
-                src/.*py|
-                tests/.*py|
-            )$
-
-    -   id: pylint
-        name: pylint
-        entry: pylint
-        types: [python]
-        language: system

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,14 +1,12 @@
-# -*- coding: utf-8 -*-
 """Configuration file for the Sphinx documentation builder.
 
 This file only contains a selection of the most common options. For a full list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
-# pylint: disable=invalid-name
 import aiida_shell
 
 project = 'aiida-shell'
-copyright = 'Sebastiaan P. Huber 2022 - 2023'  # pylint: disable=redefined-builtin
+copyright = 'Sebastiaan P. Huber 2022 - 2023'
 release = aiida_shell.__version__
 
 extensions = ['sphinx_copybutton', 'sphinx_click', 'sphinx.ext.intersphinx']
@@ -23,7 +21,7 @@ html_theme_options = {
     'logo': {
         'image_light': '_static/logo-text.svg',
         'image_dark': '_static/logo-text-light.svg',
-    }
+    },
 }
 html_context = {
     'github_user': 'sphuber',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,22 +37,18 @@ tracker = 'https://github.com/sphuber/aiida-shell/issues'
 source = 'https://github.com/sphuber/aiida-shell'
 
 [project.optional-dependencies]
+dev = [
+    'mypy==0.981',
+    'pre-commit',
+    'pgtest~=1.3,>=1.3.1',
+    'pytest~=6.2',
+    'pytest-regressions',
+]
 docs = [
     'pydata-sphinx-theme~=0.14.3',
     'sphinx~=7.2',
     'sphinx-copybutton~=0.5.0',
     'sphinx-click~=4.0',
-]
-pre-commit = [
-    'mypy==0.981',
-    'pre-commit~=2.17',
-    'pylint==2.13.7',
-    'pylint-aiida~=0.1.1',
-]
-tests = [
-    'pgtest~=1.3,>=1.3.1',
-    'pytest~=6.2',
-    'pytest-regressions',
 ]
 
 [project.entry-points.'aiida.calculations']
@@ -81,11 +77,28 @@ exclude = [
 line-length = 120
 fail-on-change = true
 
-[tool.isort]
-force_sort_within_sections = true
-include_trailing_comma = true
-line_length = 120
-multi_line_output = 3
+[tool.ruff]
+line-length = 120
+select = [
+  'E',    # pydocstyle
+  'W',    # pydocstyle
+  'F',    # pyflakes
+  'I',    # isort
+  'N',    # pep8-naming
+  'D',    # pydocstyle
+  'PLC',  # pylint-convention
+  'PLE',  # pylint-error
+  'PLR',  # pylint-refactor
+  'PLW',  # pylint-warning
+  'RUF',  # ruff
+]
+ignore = [
+    'D203',  # Incompatible with D211 `no-blank-line-before-class`
+    'D213',  # Incompatible with D212 `multi-line-summary-second-line`
+]
+
+[tool.ruff.format]
+quote-style = 'single'
 
 [tool.mypy]
 show_error_codes = true
@@ -108,37 +121,7 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.pydocstyle]
-ignore = [
-    'D104',
-    'D203',
-    'D213'
-]
-
-[tool.pylint.master]
-load-plugins = ['pylint_aiida']
-
 [tool.pytest.ini_options]
 filterwarnings = [
     'ignore:Creating AiiDA configuration folder.*:UserWarning'
 ]
-
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint.messages_control]
-disable = [
-    'duplicate-code',
-    'import-outside-toplevel',
-    'inconsistent-return-statements',
-    'too-many-ancestors',
-]
-
-[tool.yapf]
-align_closing_bracket_with_visual_indent = true
-based_on_style = 'google'
-coalesce_brackets = true
-column_limit = 120
-dedent_closing_brackets = true
-indent_dictionary_value = false
-split_arguments_when_comma_terminated = true

--- a/src/aiida_shell/__init__.py
+++ b/src/aiida_shell/__init__.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 """AiiDA plugin that makes running shell commands easy."""
-from .calculations import ShellJob
-from .data import ShellCode
-from .engine import launch_shell_job
-from .parsers import ShellParser
+from .calculations import ShellJob  # noqa
+from .data import ShellCode  # noqa
+from .engine import launch_shell_job  # noqa
+from .parsers import ShellParser  # noqa
 
 __version__ = '0.5.3'

--- a/src/aiida_shell/calculations/__init__.py
+++ b/src/aiida_shell/calculations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.calculations`."""
 from .shell import ShellJob
 

--- a/src/aiida_shell/data/__init__.py
+++ b/src/aiida_shell/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.data`."""
 from .code import ShellCode
 from .entry_point import EntryPointData

--- a/src/aiida_shell/data/code.py
+++ b/src/aiida_shell/data/code.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Code that represents a shell command."""
 from __future__ import annotations
 

--- a/src/aiida_shell/data/entry_point.py
+++ b/src/aiida_shell/data/entry_point.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin to store a reference to an entry point."""
 from __future__ import annotations
 
@@ -85,8 +84,12 @@ class EntryPointData(Data):
             )
 
         keys = (
-            self.KEY_ATTRIBUTES_NAME, self.KEY_ATTRIBUTES_GROUP, self.KEY_ATTRIBUTES_VALUE, self.KEY_ATTRIBUTES_MODULE,
-            self.KEY_ATTRIBUTES_ATTR, self.KEY_ATTRIBUTES_EXTRAS
+            self.KEY_ATTRIBUTES_NAME,
+            self.KEY_ATTRIBUTES_GROUP,
+            self.KEY_ATTRIBUTES_VALUE,
+            self.KEY_ATTRIBUTES_MODULE,
+            self.KEY_ATTRIBUTES_ATTR,
+            self.KEY_ATTRIBUTES_EXTRAS,
         )
         attributes = {key: getattr(entry_point, key) for key in keys}
         attributes[self.KEY_ATTRIBUTES_VERSION] = VERSION_PROVIDER.get_version_info(loaded)['version'].get('plugin')
@@ -102,6 +105,6 @@ class EntryPointData(Data):
         entry_point = EntryPoint(
             name=attributes[self.KEY_ATTRIBUTES_NAME],
             group=attributes[self.KEY_ATTRIBUTES_GROUP],
-            value=attributes[self.KEY_ATTRIBUTES_VALUE]
+            value=attributes[self.KEY_ATTRIBUTES_VALUE],
         )
         return entry_point.load()

--- a/src/aiida_shell/data/pickled.py
+++ b/src/aiida_shell/data/pickled.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Data plugin to store (almost) any Python object by pickling it."""
 from __future__ import annotations
 
@@ -6,9 +5,9 @@ import importlib.metadata
 import io
 import typing as t
 
+import dill
 from aiida.common.log import AIIDA_LOGGER
 from aiida.orm import SinglefileData
-import dill
 
 LOGGER = AIIDA_LOGGER.getChild('pickled_data')
 
@@ -133,7 +132,7 @@ class PickledData(SinglefileData):
 
         try:
             unpickled = self.get_unpickler()(pickled)
-        except Exception as exception:  # pylint: disable=broad-except
+        except Exception as exception:
             raise ValueError('The pickled object could not be unpickled.') from exception
 
         return unpickled

--- a/src/aiida_shell/engine/__init__.py
+++ b/src/aiida_shell/engine/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.engine`."""
 from .launchers import launch_shell_job
 

--- a/src/aiida_shell/engine/launchers/__init__.py
+++ b/src/aiida_shell/engine/launchers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.engine.launchers`."""
 from .shell_job import launch_shell_job
 

--- a/src/aiida_shell/engine/launchers/shell_job.py
+++ b/src/aiida_shell/engine/launchers/shell_job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Convenience wrapper function to simplify the interface to launch a :class:`aiida_shell.ShellJob` job."""
 from __future__ import annotations
 
@@ -20,7 +19,7 @@ __all__ = ('launch_shell_job',)
 LOGGER = logging.getLogger('aiida_shell')
 
 
-def launch_shell_job(  # pylint: disable=too-many-arguments
+def launch_shell_job(  # noqa: PLR0913
     command: str | AbstractCode,
     arguments: list[str] | str | None = None,
     nodes: t.Mapping[str, str | pathlib.Path | Data] | None = None,
@@ -113,7 +112,7 @@ def prepare_code(command: str, computer: Computer | None = None) -> AbstractCode
                     f'failed to determine the absolute path of the command on the computer: {stderr}'
                 ) from exception
 
-        code = ShellCode(  # type: ignore[assignment]
+        code = ShellCode(
             label=command, computer=computer, filepath_executable=executable, default_calc_job_plugin='core.shell'
         ).store()
 
@@ -149,8 +148,8 @@ def prepare_computer(computer: Computer | None = None) -> Computer:
                 scheduler_type='core.direct',
                 workdir=tempfile.gettempdir(),
             ).store()
-            computer.configure(safe_interval=0.)
-            computer.set_minimum_job_poll_interval(0.)
+            computer.configure(safe_interval=0.0)
+            computer.set_minimum_job_poll_interval(0.0)
             computer.set_default_mpiprocs_per_machine(1)
 
     default_user = computer.backend.default_user
@@ -172,7 +171,6 @@ def convert_nodes_single_file_data(nodes: t.Mapping[str, str | pathlib.Path | Da
     processed_nodes: t.MutableMapping[str, Data] = {}
 
     for key, value in nodes.items():
-
         if isinstance(value, Data):
             processed_nodes[key] = value
             continue

--- a/src/aiida_shell/parsers/__init__.py
+++ b/src/aiida_shell/parsers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for :mod:`aiida_shell.parsers`."""
 from .shell import ShellParser
 

--- a/src/aiida_shell/parsers/shell.py
+++ b/src/aiida_shell/parsers/shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #
@@ -35,7 +34,7 @@ class ShellParser(Parser):
         if 'parser' in self.node.inputs:
             try:
                 self.call_parser_hook(dirpath)
-            except Exception as exception:  # pylint: disable=broad-except
+            except Exception as exception:
                 return self.exit_codes.ERROR_PARSER_HOOK_EXCEPTED.format(exception=exception)
 
         if missing_filepaths:

--- a/tests/calculations/__init__.py
+++ b/tests/calculations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`aiida_shell.calculations`."""

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -1,18 +1,15 @@
-# -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_shell.calculations.shell` module."""
 import io
 import pathlib
 
+import pytest
 from aiida.common.datastructures import CodeInfo
 from aiida.orm import Data, Float, FolderData, Int, List, RemoteData, SinglefileData, Str
-import pytest
-
 from aiida_shell.calculations.shell import ShellJob
 from aiida_shell.data import EntryPointData, PickledData
 
 
-def custom_parser(self, dirpath):  # pylint: disable=unused-argument
+def custom_parser(self, dirpath):
     """Implement a custom parser to test the ``parser`` input for a ``ShellJob``."""
 
 
@@ -27,7 +24,7 @@ def test_code(generate_calc_job, generate_code):
     assert calc_info.codes_info[0].code_uuid == code.uuid
     assert calc_info.codes_info[0].cmdline_params == []
     assert calc_info.codes_info[0].stdout_name == ShellJob.FILENAME_STDOUT
-    assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert calc_info.retrieve_temporary_list == list(ShellJob.DEFAULT_RETRIEVED_TEMPORARY)
     assert not list(dirpath.iterdir())
 
 
@@ -38,14 +35,14 @@ def test_nodes_single_file_data(generate_calc_job, generate_code):
         'nodes': {
             'xa': SinglefileData(io.StringIO('content')),
             'xb': SinglefileData(io.StringIO('content')),
-        }
+        },
     }
     dirpath, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
 
     assert code_info.cmdline_params == []
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
-    assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert calc_info.retrieve_temporary_list == list(ShellJob.DEFAULT_RETRIEVED_TEMPORARY)
     assert sorted(calc_info.provenance_exclude_list) == ['xa', 'xb']
     assert sorted([p.name for p in dirpath.iterdir()]) == ['xa', 'xb']
 
@@ -67,17 +64,14 @@ def test_nodes_folder_data(generate_calc_job, generate_code, tmp_path):
             'flat_explicit': folder_flat,
             'nested_explicit': folder_nested,
         },
-        'filenames': {
-            'flat_explicit': 'sub',
-            'nested_explicit': 'sub'
-        }
+        'filenames': {'flat_explicit': 'sub', 'nested_explicit': 'sub'},
     }
     dirpath, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
 
     assert code_info.cmdline_params == ['nested', 'sub']
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
-    assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert calc_info.retrieve_temporary_list == list(ShellJob.DEFAULT_RETRIEVED_TEMPORARY)
     assert sorted(calc_info.provenance_exclude_list) == ['dir', 'file_a.txt', 'file_b.txt', 'sub']
     assert sorted([p.name for p in dirpath.iterdir()]) == ['dir', 'file_a.txt', 'file_b.txt', 'sub']
     assert sorted([p.name for p in (dirpath / 'dir').iterdir()]) == ['file_a.txt', 'file_b.txt']
@@ -96,11 +90,7 @@ def test_nodes_remote_data(generate_calc_job, generate_code, tmp_path, aiida_loc
         'nodes': {
             'remote': RemoteData(remote_path=str(tmp_path.absolute()), computer=aiida_localhost),
         },
-        'metadata': {
-            'options': {
-                'use_symlinks': use_symlinks
-            }
-        }
+        'metadata': {'options': {'use_symlinks': use_symlinks}},
     }
     _, calc_info = generate_calc_job('core.shell', inputs)
 
@@ -121,14 +111,14 @@ def test_nodes_base_types(generate_calc_job, generate_code):
             'float': Float(1.0),
             'int': Int(2),
             'str': Str('string'),
-        }
+        },
     }
     _, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
 
     assert code_info.cmdline_params == ['1.0', '2', 'string']
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
-    assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert calc_info.retrieve_temporary_list == list(ShellJob.DEFAULT_RETRIEVED_TEMPORARY)
 
 
 def test_nodes_single_file_data_filename(generate_calc_job, generate_code):
@@ -149,22 +139,23 @@ def test_nodes_single_file_data_filename(generate_calc_job, generate_code):
         },
         'filenames': {
             'xb': 'filename_b',
-        }
+        },
     }
     dirpath, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
 
     assert code_info.cmdline_params == []
     assert code_info.stdout_name == ShellJob.FILENAME_STDOUT
-    assert calc_info.retrieve_temporary_list == ShellJob.DEFAULT_RETRIEVED_TEMPORARY
+    assert calc_info.retrieve_temporary_list == list(ShellJob.DEFAULT_RETRIEVED_TEMPORARY)
     assert sorted([p.name for p in dirpath.iterdir()]) == ['filename_b', 'single_file_a', 'xc']
 
 
 @pytest.mark.parametrize(
-    'arguments, exception', (
+    'arguments, exception',
+    (
         (['{place}{holder}'], r'argument `.*` is invalid as it contains more than one placeholder.'),
         (['{placeholder}'], r'argument placeholder `.*` not specified in `nodes`.'),
-    )
+    ),
 )
 def test_arguments_invalid(generate_calc_job, generate_code, arguments, exception):
     """Test the ``arguments`` input with invalid placeholders."""
@@ -191,9 +182,7 @@ def test_arguments_files(generate_calc_job, generate_code):
     inputs = {
         'code': generate_code(),
         'arguments': arguments,
-        'nodes': {
-            'file_a': SinglefileData(io.StringIO('content'))
-        },
+        'nodes': {'file_a': SinglefileData(io.StringIO('content'))},
     }
     _, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
@@ -216,7 +205,7 @@ def test_arguments_files_filenames(generate_calc_job, generate_code):
         'filenames': {
             'file_a': 'custom_filename',
             'file_b': 'nested/custom_filename',
-        }
+        },
     }
     _, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
@@ -228,21 +217,15 @@ def test_filename_stdin(generate_calc_job, generate_code, file_regression):
     inputs = {
         'code': generate_code('cat'),
         'arguments': List(['{filename}']),
-        'nodes': {
-            'filename': SinglefileData(io.StringIO('content'))
-        },
-        'metadata': {
-            'options': {
-                'filename_stdin': 'filename'
-            }
-        }
+        'nodes': {'filename': SinglefileData(io.StringIO('content'))},
+        'metadata': {'options': {'filename_stdin': 'filename'}},
     }
     tmp_path, calc_info = generate_calc_job('core.shell', inputs, presubmit=True)
     code_info = calc_info.codes_info[0]
     assert code_info.stdin_name == 'filename'
 
     options = ShellJob.spec_metadata['options']
-    filename_submit_script = options['submit_script_filename'].default  # type: ignore[index,union-attr]
+    filename_submit_script = options['submit_script_filename'].default
     file_regression.check((pathlib.Path(tmp_path) / filename_submit_script).read_text(), encoding='utf-8')
 
 
@@ -264,11 +247,12 @@ def test_redirect_stderr(generate_calc_job, generate_code, redirect_stderr):
 
 
 @pytest.mark.parametrize(
-    'outputs, message', (
+    'outputs, message',
+    (
         ([ShellJob.FILENAME_STATUS], r'`.*` is a reserved output filename and cannot be used in `outputs`.'),
         ([ShellJob.FILENAME_STDERR], r'`.*` is a reserved output filename and cannot be used in `outputs`.'),
         ([ShellJob.FILENAME_STDOUT], r'`.*` is a reserved output filename and cannot be used in `outputs`.'),
-    )
+    ),
 )
 def test_validate_outputs(generate_calc_job, generate_code, outputs, message):
     """Test the validator for the ``outputs`` argument."""
@@ -277,10 +261,11 @@ def test_validate_outputs(generate_calc_job, generate_code, outputs, message):
 
 
 @pytest.mark.parametrize(
-    'node_cls, message', (
+    'node_cls, message',
+    (
         (Data, r'.*Unsupported node type for `.*` in `nodes`: .* does not have the `value` property.'),
         (Int, r'.*Casting `value` to `str` for `.*` in `nodes` excepted: .*'),
-    )
+    ),
 )
 def test_validate_nodes(generate_calc_job, generate_code, node_cls, message, monkeypatch):
     """Test the validator for the ``nodes`` argument."""
@@ -300,12 +285,13 @@ def test_validate_nodes(generate_calc_job, generate_code, node_cls, message, mon
 
 
 @pytest.mark.parametrize(
-    'arguments, message', (
+    'arguments, message',
+    (
         (['string', 1], r'.*all elements of the `arguments` input should be strings'),
         (['string', {input}], r'.*all elements of the `arguments` input should be strings'),
         (['<', '{filename}'], r'`<` cannot be specified in the `arguments`.*'),
         (['{filename}', '>'], r'the symbol `>` cannot be specified in the `arguments`.*'),
-    )
+    ),
 )
 def test_validate_arguments(generate_calc_job, generate_code, arguments, message):
     """Test the validator for the ``arguments`` argument."""
@@ -319,7 +305,7 @@ def test_build_process_label(generate_calc_job, generate_code):
     executable = '/bin/echo'
     code = generate_code(executable, computer_label=computer, label='echo')
     process = generate_calc_job('core.shell', {'code': code}, return_process=True)
-    assert process._build_process_label() == f'ShellJob<{code.full_label}>'  # pylint: disable=protected-access
+    assert process._build_process_label() == f'ShellJob<{code.full_label}>'
 
 
 def test_submit_to_daemon(generate_code, submit_and_await):
@@ -334,10 +320,7 @@ def test_submit_to_daemon(generate_code, submit_and_await):
 def test_parser(generate_calc_job, generate_code):
     """Test the ``parser`` input for valid input."""
     process = generate_calc_job(
-        'core.shell', inputs={
-            'code': generate_code(),
-            'parser': custom_parser
-        }, return_process=True
+        'core.shell', inputs={'code': generate_code(), 'parser': custom_parser}, return_process=True
     )
     assert isinstance(process.inputs.parser, PickledData)
 
@@ -348,10 +331,7 @@ def test_parser_entry_point(generate_calc_job, generate_code, entry_points):
     entry_points.add(custom_parser, entry_point_name)
 
     process = generate_calc_job(
-        'core.shell', inputs={
-            'code': generate_code(),
-            'parser': entry_point_name
-        }, return_process=True
+        'core.shell', inputs={'code': generate_code(), 'parser': entry_point_name}, return_process=True
     )
     assert isinstance(process.inputs.parser, EntryPointData)
 
@@ -372,8 +352,9 @@ def test_parser_over_daemon(generate_code, submit_and_await):
     """Test submitting a ``ShellJob`` with a custom parser over the daemon."""
     value = 'testing'
 
-    def parser(self, dirpath):  # pylint: disable=unused-argument
-        from aiida.orm import Str  # pylint: disable=reimported
+    def parser(self, dirpath):
+        from aiida.orm import Str
+
         return {'string': Str((dirpath / 'stdout').read_text().strip())}
 
     builder = generate_code('/bin/echo').get_builder()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
 """Module with test fixtures."""
 from __future__ import annotations
 
@@ -9,6 +7,7 @@ import tempfile
 import typing as t
 import uuid
 
+import pytest
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcInfo
 from aiida.common.folders import Folder
@@ -19,11 +18,9 @@ from aiida.engine.utils import instantiate_process
 from aiida.manage.manager import get_manager
 from aiida.orm import CalcJobNode, Computer, FolderData
 from aiida.plugins import CalculationFactory, ParserFactory
-import pytest
-
 from aiida_shell import ShellCode
 
-pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+pytest_plugins = ['aiida.manage.tests.pytest_fixtures']
 
 
 @pytest.fixture(scope='session')
@@ -44,7 +41,7 @@ def daemon_client(aiida_profile):
         # Give an additional grace period by manually waiting for the daemon to be stopped. In certain unit test
         # scenarios, the built in wait time in ``daemon_client.stop_daemon`` is not sufficient and even though the
         # daemon is stopped, ``daemon_client.is_daemon_running`` will return false for a little bit longer.
-        daemon_client._await_condition(  # pylint: disable=protected-access
+        daemon_client._await_condition(
             lambda: not daemon_client.is_daemon_running,
             DaemonTimeoutException('The daemon failed to stop.'),
         )
@@ -86,7 +83,7 @@ def generate_calc_job(tmp_path):
         entry_point_name: str,
         inputs: dict[str, t.Any] | None = None,
         return_process: bool = False,
-        presubmit: bool = False
+        presubmit: bool = False,
     ) -> tuple[pathlib.Path, CalcInfo] | CalcJob:
         """Create a :class:`aiida.engine.CalcJob` instance with the given inputs.
 
@@ -131,7 +128,7 @@ def generate_calc_job_node(generate_computer):
                 flat_inputs.append((prefix + key, value))
         return flat_inputs
 
-    def factory(filepath_retrieved: pathlib.Path = None, inputs: dict = None):
+    def factory(filepath_retrieved: pathlib.Path | None = None, inputs: dict | None = None):
         """Create and return a :class:`aiida.orm.CalcJobNode` instance."""
         node = CalcJobNode(computer=generate_computer(), process_type='aiida.calculations:core.shell')
         node.set_retrieve_list(['stdout'])
@@ -174,8 +171,8 @@ def generate_computer():
                 workdir=tempfile.gettempdir(),
             ).store()
 
-        computer.configure(safe_interval=0.)
-        computer.set_minimum_job_poll_interval(0.)
+        computer.configure(safe_interval=0.0)
+        computer.set_minimum_job_poll_interval(0.0)
         computer.set_default_mpiprocs_per_machine(1)
 
         return computer
@@ -204,10 +201,7 @@ def generate_code(generate_computer):
             return ShellCode.collection.get(**filters)
         except exceptions.NotExistent:
             return ShellCode(
-                label=label,
-                computer=computer,
-                filepath_executable=executable,
-                default_calc_job_plugin=entry_point_name
+                label=label, computer=computer, filepath_executable=executable, default_calc_job_plugin=entry_point_name
             ).store()
 
     return factory

--- a/tests/data/test_code.py
+++ b/tests/data/test_code.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`aiida_shell.data.code`."""
 import pytest
-
 from aiida_shell.data.code import ShellCode
 
 
@@ -27,10 +25,13 @@ def test_constructor_invalid(generate_computer):
         )
 
 
-@pytest.mark.parametrize(('value', 'exception'), (
-    ('core.shell', None),
-    ('core.arithmetic.add', r'`default_calc_job_plugin` has to be `core.shell`, but got: .*'),
-))
+@pytest.mark.parametrize(
+    ('value', 'exception'),
+    (
+        ('core.shell', None),
+        ('core.arithmetic.add', r'`default_calc_job_plugin` has to be `core.shell`, but got: .*'),
+    ),
+)
 def test_validate_default_calc_job_plugin(value, exception):
     """Test the constructor raises if ``default_calc_job_plugin`` is not ``core.shell``."""
     if exception:

--- a/tests/data/test_entry_point.py
+++ b/tests/data/test_entry_point.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_shell.data.entry_point` module."""
+import pytest
 from aiida.orm import load_node
 from aiida.plugins.entry_point import get_entry_point
-from importlib_metadata import EntryPoint
-import pytest
-
 from aiida_shell.data.entry_point import EntryPointData
+from importlib_metadata import EntryPoint
 
 InvalidEntryPoint = EntryPoint('b', 'a', group='c')
 InconsistentEntryPoint = EntryPoint('b', 'aiida_shell.data.pickled:PickledData', group='c')
@@ -29,31 +26,17 @@ def test_constructor(entry_point):
 
 
 @pytest.mark.parametrize(
-    'kwargs, exception, matches', (
+    'kwargs, exception, matches',
+    (
         ({}, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
-        ({
-            'group': 'some.group'
-        }, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
-        ({
-            'name': 'some.name'
-        }, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
-        ({
-            'entry_point': 'invalid_type'
-        }, TypeError, r'Got object of type .*, expecting .*'),
-        ({
-            'group': 'a',
-            'name': 'a'
-        }, ValueError, r'entry point with group `a` and name `a` does not exist.'),
-        ({
-            'entry_point': InvalidEntryPoint
-        }, ValueError, r'entry point .* could not be loaded.'),
-        ({
-            'entry_point': InconsistentEntryPoint
-        }, ValueError, r'Inconsistent.*: the `name` and `group` of .* do not'),
-        ({
-            'entry_point': DifferentEntryPoint
-        }, ValueError, r'Inconsistent.*: the `name` and `group` of .* point'),
-    )
+        ({'group': 'some.group'}, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
+        ({'name': 'some.name'}, ValueError, r'Define either the `entry_point` directly or the `group` and `name`\.'),
+        ({'entry_point': 'invalid_type'}, TypeError, r'Got object of type .*, expecting .*'),
+        ({'group': 'a', 'name': 'a'}, ValueError, r'entry point with group `a` and name `a` does not exist.'),
+        ({'entry_point': InvalidEntryPoint}, ValueError, r'entry point .* could not be loaded.'),
+        ({'entry_point': InconsistentEntryPoint}, ValueError, r'Inconsistent.*: the `name` and `group` of .* do not'),
+        ({'entry_point': DifferentEntryPoint}, ValueError, r'Inconsistent.*: the `name` and `group` of .* point'),
+    ),
 )
 def test_constructor_invalid(kwargs, exception, matches):
     """Test the constructor of :class:`~aiida_shell.data.entry_point.EntryPointData`."""
@@ -77,5 +60,6 @@ def test_load():
 def test_version():
     """Test that the package version of the wrapped entry point is stored in the attributes."""
     from aiida_shell import __version__
+
     node = EntryPointData(group='aiida.data', name='core.entry_point')
     assert node.base.attributes.get(EntryPointData.KEY_ATTRIBUTES_VERSION) == __version__

--- a/tests/data/test_pickled.py
+++ b/tests/data/test_pickled.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_shell.data.pickled` module."""
-from aiida.orm import Node, load_node
 import dill
 import pytest
-
+from aiida.orm import Node, load_node
 from aiida_shell.data.pickled import PickledData
 
 

--- a/tests/engine/launchers/test_shell_job.py
+++ b/tests/engine/launchers/test_shell_job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_shell.engine.launchers.shell_job` module."""
 import datetime
 import io
@@ -6,10 +5,9 @@ import json
 import pathlib
 import shutil
 
+import pytest
 from aiida.engine import WorkChain, run_get_node, workfunction
 from aiida.orm import AbstractCode, Float, Int, RemoteData, SinglefileData, Str
-import pytest
-
 from aiida_shell.calculations.shell import ShellJob
 from aiida_shell.engine.launchers.shell_job import launch_shell_job
 
@@ -142,9 +140,7 @@ def test_nodes_remote_data(tmp_path, aiida_localhost, use_symlinks):
         nodes={'remote': remote_data},
         outputs=['file_a.txt'],
         metadata={
-            'options': {
-                'use_symlinks': use_symlinks
-            },
+            'options': {'use_symlinks': use_symlinks},
         },
     )
     assert node.is_finished_ok
@@ -247,8 +243,9 @@ def test_submit_inside_workfunction(submit_and_await):
 def test_parser():
     """Test the ``parser`` argument."""
 
-    def parser(self, dirpath):  # pylint: disable=unused-argument
-        from aiida.orm import Str  # pylint: disable=reimported,redefined-outer-name
+    def parser(self, dirpath):
+        from aiida.orm import Str
+
         return {'string': Str((dirpath / 'stdout').read_text().strip())}
 
     value = 'test_string'
@@ -266,11 +263,11 @@ def test_parser_non_stdout():
     """
     filename = 'results.json'
 
-    def parser(self, dirpath):  # pylint: disable=unused-argument
-        # pylint: disable=reimported,redefined-outer-name
+    def parser(self, dirpath):
         import json
 
         from aiida.orm import Dict
+
         return {'json': Dict(json.load((dirpath / filename).open()))}
 
     dictionary = {'a': 1}
@@ -279,10 +276,7 @@ def test_parser_non_stdout():
         arguments=['{json}'],
         nodes={'json': SinglefileData(io.StringIO(json.dumps(dictionary)))},
         parser=parser,
-        metadata={'options': {
-            'output_filename': filename,
-            'additional_retrieve': [filename]
-        }}
+        metadata={'options': {'output_filename': filename, 'additional_retrieve': [filename]}},
     )
 
     assert node.is_finished_ok

--- a/tests/parsers/test_shell.py
+++ b/tests/parsers/test_shell.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_shell.parsers.shell` module."""
 import copy
 import pathlib
 
-from aiida.orm import FolderData, List, SinglefileData
 import pytest
-
+from aiida.orm import FolderData, List, SinglefileData
 from aiida_shell.calculations.shell import ShellJob
 
 
@@ -118,10 +115,13 @@ def test_outputs_missing(parse_calc_job, create_retrieved_temporary):
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_FILEPATHS_MISSING.status
 
 
-@pytest.mark.parametrize(('filename', 'link_label'), (
-    ('filename-with-dashes.txt', 'filename_with_dashes_txt'),
-    ('file@@name.txt', 'file_name_txt'),
-))
+@pytest.mark.parametrize(
+    ('filename', 'link_label'),
+    (
+        ('filename-with-dashes.txt', 'filename_with_dashes_txt'),
+        ('file@@name.txt', 'file_name_txt'),
+    ),
+)
 def test_outputs_link_labels(parse_calc_job, create_retrieved_temporary, filename, link_label):
     """Test that filenames are converted into valid link labels.
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_shell` module."""
-from packaging.version import Version, parse
-
 import aiida_shell
+from packaging.version import Version, parse
 
 
 def test_version():


### PR DESCRIPTION
The `ruff` tool is adopted in the pre-commit. This completely replaces the hooks `pylint`, `yapf`, `pydocstyle` and `isort`. The encoding pragma is removed since this project is Python 3 only and all files are utf-8 encoded, which is the default assumed by the Python interpreter.

For formatting, `ruff` implements the same style as `black`. The only configuration options that are changed are to set the line length to 120 and to keep single quotes, instead of double quotes.