### PR TITLE
Docs: Fix path to image in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="text-align: center;">
-    <img src="docs/source/images/logo-text.svg" style="width:100%" alt="aiida-shell"/>
+    <img src="docs/source/_static/logo-text.svg" style="width:100%" alt="aiida-shell"/>
 </div>
 
 [![PyPI version](https://badge.fury.io/py/aiida-shell.svg)](https://badge.fury.io/py/aiida-shell)


### PR DESCRIPTION
The image was moved to `docs/source/_static` in a recent commit.