### PR TITLE
Docs: Add the changelog to the documentation

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,0 +1,2 @@
+```{include} ../../CHANGELOG.md
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ project = 'aiida-shell'
 copyright = 'Sebastiaan P. Huber 2022 - 2023'
 release = aiida_shell.__version__
 
-extensions = ['sphinx_copybutton', 'sphinx_click', 'sphinx.ext.intersphinx']
+extensions = ['myst_parser', 'sphinx_copybutton', 'sphinx_click', 'sphinx.ext.intersphinx']
 
 html_theme = 'pydata_sphinx_theme'
 html_theme_options = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,3 +82,4 @@ Please refer to the `CITATION.cff <https://github.com/sphuber/aiida-shell/blob/m
 
    installation
    howto
+   changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     'pytest-regressions',
 ]
 docs = [
+    'myst-parser',
     'pydata-sphinx-theme~=0.14.3',
     'sphinx~=7.2',
     'sphinx-copybutton~=0.5.0',


### PR DESCRIPTION
This uses the `myst-parser` package to automatically convert the markdown format of `CHANGELOG.md` to restructured text.