### PR TITLE
Devops: Update `setup-python` dependency in CI/CD to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,8 +16,8 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.10
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.10'
 
@@ -32,18 +32,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
-
-        -   name: Set up Python
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.10'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python dependencies
             run: pip install -e .[dev]
@@ -69,18 +63,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
-        -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+        -   name: Install Python ${{ matrix.python-version }}
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install system dependencies
             run: sudo apt update && sudo apt install postgresql
@@ -101,8 +89,8 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.10
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            id: cache-pip
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
-
         -   name: Install Python
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.10'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python package and dependencies
             run: pip install -e .[dev]
@@ -49,19 +42,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            id: cache-pip
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
         -   name: Install Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install system dependencies
             run: sudo apt update && sudo apt install postgresql


### PR DESCRIPTION
This now comes with built-in support for caching of Python dependencies allowing the workflows to be simplified by getting rid of the `cache` action.