### PR TITLE
Dependencies: Update `aiida-core~=2.4`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11']
 
         services:
             rabbitmq:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11']
 
         services:
             rabbitmq:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,6 @@
 
     It is now possible to add a directory to the `outputs` and it will be attached as a `FolderData` output node:
     ```python
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
@@ -139,13 +138,12 @@
     Certain shell commands require input to be passed through the stdin file descriptor.
     To reproduce this behaviour, the file that should be redirected through stdin can be defined using the `metadata.option.filename_stdin` input:
     ```python
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'cat',
         nodes={
-            'input': SinglefileData(StringIO('string a'))
+            'input': SinglefileData.from_string('string a')
         },
         metadata={'options': {'filename_stdin': 'input'}}
     )

--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -47,15 +47,14 @@ To specify where on the command line the files should be passed, use placeholder
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'cat',
         arguments='{file_a} {file_b}',
         nodes={
-            'file_a': SinglefileData(StringIO('string a')),
-            'file_b': SinglefileData(StringIO('string b')),
+            'file_a': SinglefileData.from_string('string a'),
+            'file_b': SinglefileData.from_string('string b'),
         }
     )
     print(results['stdout'].get_content())
@@ -74,14 +73,13 @@ If the ``SinglefileData.filename`` was explicitly set when creating the node, th
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'cat',
         arguments='{file_a}',
         nodes={
-            'file_a': SinglefileData(StringIO('string a'), filename='filename.txt'),
+            'file_a': SinglefileData.from_string('string a', filename='filename.txt'),
         }
     )
     print(results['stdout'].get_content())
@@ -92,14 +90,13 @@ If the filename of the ``SinglefileData`` cannot be controlled, alternatively ex
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'cat',
         arguments='{file_a}',
         nodes={
-            'file_a': SinglefileData(StringIO('string a')),
+            'file_a': SinglefileData.from_string('string a'),
         },
         filenames={
             'file_a': 'filename.txt'
@@ -299,13 +296,12 @@ To reproduce this behaviour, the file that should be redirected through stdin ca
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'cat',
         nodes={
-            'input': SinglefileData(StringIO('string a'))
+            'input': SinglefileData.from_string('string a')
         },
         metadata={'options': {'filename_stdin': 'input'}}
     )
@@ -353,14 +349,13 @@ Any other output files that need to be captured can be defined using the ``outpu
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'sort',
         arguments='{input} --output sorted',
         nodes={
-            'input': SinglefileData(StringIO('2\n5\n3')),
+            'input': SinglefileData.from_string('2\n5\n3'),
         },
         outputs=['sorted']
     )
@@ -379,14 +374,13 @@ These output files can be captured by specifying the ``outputs`` as ``['x*']``:
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
         'split',
         arguments='-l 1 {single_file}',
         nodes={
-            'single_file': SinglefileData(StringIO('line 0\nline 1\nline 2\n')),
+            'single_file': SinglefileData.from_string('line 0\nline 1\nline 2\n'),
         },
         outputs=['x*']
     )
@@ -405,7 +399,6 @@ The following example uncompresses the tarball and captures the uncompressed fil
 
 .. code-block:: python
 
-    from io import StringIO
     from aiida.orm import SinglefileData
     from aiida_shell import launch_shell_job
     results, node = launch_shell_job(
@@ -555,7 +548,6 @@ which prints ``some output``.
 
     .. code-block:: python
 
-        from io import StringIO
         from json import dumps
         from aiida_shell import launch_shell_job
         from aiida.orm import SinglefileData
@@ -569,7 +561,7 @@ which prints ``some output``.
         results, node = launch_shell_job(
             'cat',
             arguments='{json}',
-            nodes={'json': SinglefileData(StringIO(dumps({'a': 1})))},
+            nodes={'json': SinglefileData.from_string(dumps({'a': 1}))},
             parser=parser,
             metadata={
                 'options': {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,13 @@ classifiers = [
     'Operating System :: POSIX :: Linux',
     'Operating System :: MacOS :: MacOS X',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering'
 ]
 keywords = ['aiida', 'workflows']
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'aiida-core~=2.4',
     'dill'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=2.1',
+    'aiida-core~=2.4',
     'dill'
 ]
 

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -1,5 +1,4 @@
 """Tests for the :mod:`aiida_shell.calculations.shell` module."""
-import io
 import pathlib
 
 import pytest
@@ -33,8 +32,8 @@ def test_nodes_single_file_data(generate_calc_job, generate_code):
     inputs = {
         'code': generate_code(),
         'nodes': {
-            'xa': SinglefileData(io.StringIO('content')),
-            'xb': SinglefileData(io.StringIO('content')),
+            'xa': SinglefileData.from_string('content'),
+            'xb': SinglefileData.from_string('content'),
         },
     }
     dirpath, calc_info = generate_calc_job('core.shell', inputs)
@@ -133,9 +132,9 @@ def test_nodes_single_file_data_filename(generate_calc_job, generate_code):
     inputs = {
         'code': generate_code(),
         'nodes': {
-            'xa': SinglefileData(io.StringIO('content'), filename='single_file_a'),
-            'xb': SinglefileData(io.StringIO('content')),
-            'xc': SinglefileData(io.StringIO('content')),
+            'xa': SinglefileData.from_string('content', filename='single_file_a'),
+            'xb': SinglefileData.from_string('content'),
+            'xc': SinglefileData.from_string('content'),
         },
         'filenames': {
             'xb': 'filename_b',
@@ -182,7 +181,7 @@ def test_arguments_files(generate_calc_job, generate_code):
     inputs = {
         'code': generate_code(),
         'arguments': arguments,
-        'nodes': {'file_a': SinglefileData(io.StringIO('content'))},
+        'nodes': {'file_a': SinglefileData.from_string('content')},
     }
     _, calc_info = generate_calc_job('core.shell', inputs)
     code_info = calc_info.codes_info[0]
@@ -199,8 +198,8 @@ def test_arguments_files_filenames(generate_calc_job, generate_code):
         'code': generate_code(),
         'arguments': arguments,
         'nodes': {
-            'file_a': SinglefileData(io.StringIO('content')),
-            'file_b': SinglefileData(io.StringIO('content')),
+            'file_a': SinglefileData.from_string('content'),
+            'file_b': SinglefileData.from_string('content'),
         },
         'filenames': {
             'file_a': 'custom_filename',
@@ -217,7 +216,7 @@ def test_filename_stdin(generate_calc_job, generate_code, file_regression):
     inputs = {
         'code': generate_code('cat'),
         'arguments': List(['{filename}']),
-        'nodes': {'filename': SinglefileData(io.StringIO('content'))},
+        'nodes': {'filename': SinglefileData.from_string('content')},
         'metadata': {'options': {'filename_stdin': 'filename'}},
     }
     tmp_path, calc_info = generate_calc_job('core.shell', inputs, presubmit=True)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,6 +1,5 @@
 """Tests for the :mod:`aiida_shell.launch` module."""
 import datetime
-import io
 import json
 import pathlib
 import shutil
@@ -97,8 +96,8 @@ def test_nodes_single_file_data():
     content_a = 'content_a'
     content_b = 'content_b'
     nodes = {
-        'file_a': SinglefileData(io.StringIO(content_a)),
-        'file_b': SinglefileData(io.StringIO(content_b)),
+        'file_a': SinglefileData.from_string(content_a),
+        'file_b': SinglefileData.from_string(content_b),
     }
     arguments = ['{file_a}', '{file_b}']
     results, node = launch_shell_job('cat', arguments=arguments, nodes=nodes)
@@ -201,7 +200,7 @@ def test_arguments_files():
     """Test a shellfunction that specifies positional and keyword CLI arguments interpolated by the ``kwargs``."""
     content = 'line 1\nline 2'
     arguments = ['-n', '1', '{single_file}']
-    nodes = {'single_file': SinglefileData(io.StringIO(content))}
+    nodes = {'single_file': SinglefileData.from_string(content)}
     results, node = launch_shell_job('head', arguments=arguments, nodes=nodes)
 
     assert node.is_finished_ok
@@ -274,7 +273,7 @@ def test_parser_non_stdout():
     results, node = launch_shell_job(
         'cat',
         arguments=['{json}'],
-        nodes={'json': SinglefileData(io.StringIO(json.dumps(dictionary)))},
+        nodes={'json': SinglefileData.from_string(json.dumps(dictionary))},
         parser=parser,
         metadata={'options': {'output_filename': filename, 'additional_retrieve': [filename]}},
     )


### PR DESCRIPTION
This allows to use `SinglefileData.from_string` to simplify constructing a new node from a string, instead of having to use `io.StringIO`.