### PR TITLE
Add `stdout` and `stderr` outputs

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -81,6 +81,11 @@ class ShellJob(CalcJob):
         options['resources'].default = {'num_machines': 1}  # type: ignore[index]
 
         spec.outputs.dynamic = True
+        spec.output('stdout', valid_type=SinglefileData, required=False,
+                    help='The file containing the standard output of the shell command.')
+        spec.output('stderr', valid_type=SinglefileData, required=False,
+                    help='The file containing the standard error of the shell command.')
+
 
         spec.exit_code(
             300,


### PR DESCRIPTION
Add the `stdout` and `stderr` outputs. I set them as `required=False`, because the `stdout` will not be out if the user set `output_filename`. And the `stderr` could not exist.

The reason I want to add this. 

AiiDA-shell provides great flexibility to the user. It lowers the barrier for people to use AiiDA. One can combine it with AiiDA-WorkTree, to provide more power. What I mean by saying that is, instead of running the calcjobs in a python script, such as:
```
results, node = launch_shell_job('pdb_fetch', '1brs')
results, node = launch_shell_job('pdb_selchain', '-A,D {pdb}', {'pdb': results['stdout']})
results, node = launch_shell_job('pdb_delhetatm', '{pdb}', {'pdb': results['stdout']})
results, node = launch_shell_job('pdb_tidy', '{pdb}', {'pdb': results['stdout']})
```
In this case, there is no checkpoint. One can use WorkTree to link all these calcjobs by passing the output of one ShellJob to another.

In the aiida-worktree, one creates a node from calcjob directly, and use the calcjob's inputs and outputs.

For the moment, I need to add a new output socket everytime I creating a shell node.
```
job1 = wt.nodes.new(shelljob, code=pdb_fetch, arguments=["1brs"])
job1.outputs.new("General", "stdout")
wt.links.new(job1.outputs["stdout"], generate_nodes1.inputs[0])
```

With this PR, one can
```
job1 = wt.nodes.new(shelljob, code=pdb_fetch, arguments=["1brs"])
wt.links.new(job1.outputs["stdout"], generate_nodes1.inputs[0])
```

A full example is
```
from aiida_worktree import node, WorkTree, build_node
from aiida import load_profile
from aiida.orm import load_code

load_profile()

pdb_fetch = load_code("pdb_fetch")
pdb_selchain = load_code("pdb_selchain")
pdb_delhetatm = load_code("pdb_delhetatm")
pdb_tidy = load_code("pdb_tidy")

shelljob = build_node({"path": "aiida_shell.calculations.shell.ShellJob"})

@node()
def generate_nodes(data):
    """Prepare the nodes"""
    return {"pdb": data}

# Create a worktree
wt = WorkTree(name="test_aiida_shell")
job1 = wt.nodes.new(shelljob, code=pdb_fetch, arguments=["1brs"])
job2 = wt.nodes.new(shelljob, code=pdb_selchain, arguments=["-A,D", "{pdb}"])
job3 = wt.nodes.new(shelljob, code=pdb_delhetatm, arguments=["{pdb}"])
job4 = wt.nodes.new(shelljob, code=pdb_tidy, arguments=["{pdb}"])
generate_nodes1 = wt.nodes.new(generate_nodes)
generate_nodes2 = wt.nodes.new(generate_nodes)
generate_nodes3 = wt.nodes.new(generate_nodes)
wt.links.new(job1.outputs["stdout"], generate_nodes1.inputs[0])
wt.links.new(generate_nodes1.outputs[0], job2.inputs["nodes"])
wt.links.new(job2.outputs["stdout"], generate_nodes2.inputs[0])
wt.links.new(generate_nodes2.outputs[0], job3.inputs["nodes"])
wt.links.new(job3.outputs["stdout"], generate_nodes3.inputs[0])
wt.links.new(generate_nodes3.outputs[0], job4.inputs["nodes"])
wt.submit()

```

This is node graph:

![Screenshot from 2024-01-19 10-28-33](https://github.com/sphuber/aiida-shell/assets/11457659/924b450b-0194-48c9-82c0-87a846355b9b)




