### PR TITLE
`ShellJob`: Detect and prevent filename clashes

### DIFF
--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -61,6 +61,16 @@ To specify where on the command line the files should be passed, use placeholder
 
 which prints ``string astring b``.
 
+.. note::
+
+    The filename with which the file is written to the working directory is taken from the ``SinglefileData.filename`` property.
+    This is set when the node is created, e.g., ``SinglefileData.from_string('content', filename='some_filename.txt')``.
+    If the ``filename`` property is the default, the key of the node in the ``nodes`` dictionary is used instead.
+
+.. warning::
+
+    If the filename overlaps with a reserved filename (i.e. ``stdout``, ``stderr`` or ``status``), the filename will be automatically changed to a unique filename by appending a random suffix.
+
 
 Running a shell command with files as arguments with specific filenames
 =======================================================================
@@ -108,7 +118,10 @@ which prints ``string a``.
 Filenames specified in the ``filenames`` input will override the filename of the ``SinglefileData`` nodes.
 Any parent directories in the filepath, for example ``some/nested/path`` in the filename ``some/nested/path/file.txt``, will be automatically created.
 
-The output filename can be anything except for ``stdout``, ``stderr`` and ``status``, which are reserved filenames.
+.. warning::
+
+    The output filename can be anything except for ``stdout``, ``stderr`` and ``status``, which are reserved filenames.
+    If these names are chosen anyway, a validation error is raised when the job is launched.
 
 
 Running a shell command with folders as arguments


### PR DESCRIPTION
Fixes #68 

So far, no validation was performed on the filenames of input nodes that
would be written to the working directory that could overlap with files
written by the plugin itself, such as `stdout` and `stderr`. This could
lead to unexpected results and often calculations failing completely.

For example, if a `SinglefileData` would be written to the working
directory with the filename `stdout`, most likely because the `filename`
attribute of the node was set to this, then this would be overwritten by
the redirection of the stdout, which is redirected to the file `stdout`
by default.

A distinction is made between clashes that happen "implicitly", meaning
the filename of the `SinglefileData` or `FolderData` just happen to
overlap, compared to "explicitly" where the user specifies a conflicting
filename in the `filenames` input. In the latter case, an exception is
raised during the validation. In the former case, the target filename is
automatically changed to a unique filename to resolve the naming issue.
This solution is chosen because this will happen often in normal use
cases of `aiida-shell`. For example, if a command is run whose stdout is
captured, it will be stored as a `SinglefileData` with the name
`stdout`. If this in turn is used as an input for a next command, this
filename will clash as `stdout` is a reserved name. This would force the
user to manually correct the problem by defining an alternative name in
`filenames`. Since this will occur so often, it is better to have the
plugin automatically solve this conflict.

There is a special case for the `FolderData` where an object contained
within it overlaps with a reserved filename. In this case, the strategy
mentioned above of automatically renaming won't work because the writing
of the contents is not done by the plugin but by the engine. Instead, an
exception is raised. Unfortunately, this is not done in the input
validation and so this will result in an excepted process. However, it
is currently not possible to put this logic in the input validation as
this would require significant refactoring.