### PR TITLE
`launch_shell_job`: Add option to keep skip resolving of `command`

### DIFF
--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -615,6 +615,33 @@ which prints ``some output``.
     The entry point will automatically be validated and wrapped in a :class:`aiida_shell.data.entry_point.EntryPointData`.
 
 
+.. _how-to:keep-command-path-relative:
+
+Keeping the command path relative
+=================================
+
+By default, :meth:`~aiida_shell.launch.launch_shell_job` automatically converts the provided command to the absolute filepath of the corresponding executable.
+This serves two purposes:
+
+1. A check to make sure the command exists on the specified computer
+2. Increases the quality of provenance
+
+The executable that a relative command resolves to on the target computer can change as a function of the environment, or simply change over time.
+Storing the actual absolute filepath of the executable avoids this, although it remains of course vulnerable to the executable itself actually being changed over time.
+
+Nevertheless, there may be use-cases where the resolving of the command is not desirable.
+To skip this step and keep the command as specified, set the ``resolve_command`` argument to ``False``:
+
+.. code-block:: python
+
+    from aiida_shell import launch_shell_job
+    results, node = launch_shell_job('date')
+    assert str(node.inputs.code.filepath_executable) == '/usr/bin/date'
+
+    results, node = launch_shell_job('date', resolve_command=False)
+    assert str(node.inputs.code.filepath_executable) == 'date'
+
+
 Customizing run environment
 ===========================
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -239,6 +239,20 @@ def test_submit_inside_workfunction(submit_and_await):
     assert isinstance(results['stdout'], SinglefileData)
 
 
+@pytest.mark.parametrize(
+    'resolve_command, executable',
+    (
+        (True, '/usr/bin/date'),
+        (False, 'date'),
+    ),
+)
+@pytest.mark.usefixtures('aiida_profile_clean')
+def test_resolve_command(resolve_command, executable):
+    """Test the ``resolve_command`` argument."""
+    _, node = launch_shell_job('date', resolve_command=resolve_command)
+    assert str(node.inputs.code.filepath_executable) == executable
+
+
 def test_parser():
     """Test the ``parser`` argument."""
 


### PR DESCRIPTION
Fixes #72 

By default, `launch_shell_job` would resolve the command to the absolute filepath of the corresponding executable. This would serve two purposes: checking the command exists and increasing the reproducibility. The relative command name may be changed on the remote over time to point to another executable. By using the absolute filepath this probability is reduced, but of course not fully avoided since the file at the absolute path can still be changed on the remote.