### PR TITLE
Set default localhost scratch to `$TMP/aiida_shell_scratch`

### DIFF
--- a/src/aiida_shell/launch.py
+++ b/src/aiida_shell/launch.py
@@ -158,7 +158,7 @@ def prepare_computer(computer: Computer | None = None) -> Computer:
                 description='Localhost automatically created by `aiida.engine.launch_shell_job`',
                 transport_type='core.local',
                 scheduler_type='core.direct',
-                workdir=tempfile.gettempdir(),
+                workdir=str(pathlib.Path(tempfile.gettempdir()) / 'aiida_shell_scratch'),
             ).store()
             computer.configure(safe_interval=0.0)
             computer.set_minimum_job_poll_interval(0.0)


### PR DESCRIPTION
Before, the scratch would be just `$TMP`. This would result in a the sharded work directories of calculation jobs to be directly in the temporary directory of the filesystem and it would be difficult to clean it up. By putting it in a subdirectory that is clearly recognizable, deleting stale working directories becomes a lot easier.