### PR TITLE
`PickledData`: Set `recurse=True` for `dill.dumps`

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -146,7 +146,7 @@ class ShellJob(CalcJob):
         :raises TypeError: If the object is not a string or callable.
         """
         if callable(value):
-            return PickledData(value)
+            return PickledData(value, recurse=True)
 
         if isinstance(value, str):
             from aiida.plugins.entry_point import get_entry_point_from_string

--- a/src/aiida_shell/data/pickled.py
+++ b/src/aiida_shell/data/pickled.py
@@ -26,25 +26,26 @@ class PickledData(SinglefileData):
     KEY_ATTRIBUTES_UNPICKLER_VERSION: str = 'pickler_version'
     """Attribute key that stores the version of the package whose function can unpickle this object."""
 
+    KEY_ATTRIBUTES_PICKLER_KWARGS: str = 'pickler_kwargs'
+    """Attribute key that stores the keyword arguments passed to the constructor which are forwarded to the pickler."""
+
     PICKLER: t.Callable[[t.Any], bytes] = dill.dumps
     """The method used to pickle the Python object."""
 
     UNPICKLER: t.Callable[[bytes], t.Any] = dill.loads
     """The method used to unpickle the Python object."""
 
-    def __init__(self, obj: t.Any):
+    def __init__(self, obj: t.Any, **kwargs: t.Any):
         """Construct a new instance by pickling the provided Python object.
 
         :raises TypeError: If the Python object cannot be pickled.
         """
-        try:
-            pickled = self.get_pickler()(obj)
-        except TypeError as exception:
-            raise TypeError(f'object of type `{type(obj)}` is not supported') from exception
+        pickled = self.get_pickler()(obj, **kwargs)
 
         super().__init__(file=io.BytesIO(pickled))
 
         self._set_unpickler_information()
+        self.base.attributes.set(self.KEY_ATTRIBUTES_PICKLER_KWARGS, kwargs)
 
     @classmethod
     def get_pickler(cls) -> t.Callable[[t.Any], bytes]:

--- a/tests/data/test_pickled.py
+++ b/tests/data/test_pickled.py
@@ -28,3 +28,12 @@ def test_load(obj):
 
     loaded = load_node(node.pk)
     assert loaded.load() == obj
+
+
+def test_kwargs():
+    """Test that kwargs passed to the constructor are forwarded to the pickler and stored in node's attributes."""
+    pickled = PickledData(Node, recurse=True).store()
+    assert pickled.base.attributes.get(PickledData.KEY_ATTRIBUTES_PICKLER_KWARGS) == {'recurse': True}
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'unsupported_kwarg'"):
+        pickled = PickledData(Node, unsupported_kwarg=True).store()


### PR DESCRIPTION
Fixes #82 

Fix `InvalidOperation` raised by `aiida-core` when pickling

To support inline custom parser functions being submitted to and
executed by the daemon, they are pickled using the `dill` library
through the `PickledData` plugin. For certain cases, the script would
hit the exception `InvalidOperation` raised by `aiida-core` in
`aiida.orm.entities.Entity.__getstate__` which is called when the
instance is attempted to be pickled by the code, which is not supported
for AiiDA's ORM entities.

The immediate cause seems to be that by default, the entire global
dictionary of the Python interpreter is pickled by `dill` and so if that
contains an AiiDA entity, the exception is hit. The entity does not even
have to be part of the parser function that is being pickled but can
just be part of the global scope. For example, the following would hit
the exception

    from aiida_shell import launch_shell_job
    from aiida.orm import Int

    def parser(self, dirpath):
        pass

    some_node = Int(1)

    results, node = launch_shell_job(
        'echo',
        arguments='some output',
        parser=parser,
    )

Merely defining the node `Int` and assigning it to a variable would be
sufficient to cause the exception to be raised. Removing it from the
scope, either by commenting out the line or deleting the variable from
memory before calling `launch_shell_job` would fix the problem.

Passing the option `recurse=True` to `dill.dumps` appears to solve the
problem. Although it is not quite understood how and why this works from
the description of the option in dill's source code:

    If *recurse=True*, then objects referred to in the global dictionary
    are recursively traced and pickled, instead of the default behavior
    of attempting to store the entire global dictionary. This is needed
    for functions defined via *exec()*.

Weirdly enough, the behavior could not be reproduced in a unit test run
through `pytest`. Maybe the global dictionary is handled differently in
this environment. Unfortunately therefore no unit test could be added.