### PR TITLE
Devops: Make use of the improved `pytest` fixtures in `aiida-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
         cache: pip
         cache-dependency-path: pyproject.toml
 
-    - name: Install system dependencies
-      run: sudo apt update && sudo apt install postgresql
-
     - name: Install Python package and dependencies
       run: pip install -e .[dev]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ requires-python = '>=3.9'
 dev = [
   'mypy==1.6.1',
   'pre-commit',
-  'pgtest~=1.3,>=1.3.1',
   'pytest~=6.2',
   'pytest-regressions'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   'Topic :: Scientific/Engineering'
 ]
 dependencies = [
-  'aiida-core@git+https://github.com/sphuber/aiida-core@fix/pytest-fixtures-pgtest-optional',
+  'aiida-core~=2.6,>=2.6.1',
   'dill'
 ]
 dynamic = ['description', 'version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   'Topic :: Scientific/Engineering'
 ]
 dependencies = [
-  'aiida-core~=2.6',
+  'aiida-core@git+https://github.com/sphuber/aiida-core@fix/pytest-fixtures-pgtest-optional',
   'dill'
 ]
 dynamic = ['description', 'version']

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -246,9 +246,9 @@ def test_submit_inside_workfunction(submit_and_await):
         (False, 'date'),
     ),
 )
-@pytest.mark.usefixtures('aiida_profile_clean')
-def test_resolve_command(resolve_command, executable):
+def test_resolve_command(aiida_profile, resolve_command, executable):
     """Test the ``resolve_command`` argument."""
+    aiida_profile.reset_storage()
     _, node = launch_shell_job('date', resolve_command=resolve_command)
     assert str(node.inputs.code.filepath_executable) == executable
 
@@ -296,15 +296,18 @@ def test_parser_non_stdout():
     assert results['json'] == dictionary
 
 
-@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('scheduler_type', ('core.direct', 'core.sge'))
-def test_preexisting_localhost_no_default_mpiprocs_per_machine(generate_computer, scheduler_type, caplog):
+def test_preexisting_localhost_no_default_mpiprocs_per_machine(
+    aiida_profile, generate_computer, scheduler_type, caplog
+):
     """Test that ``prepare_computer`` sets ``default_mpiprocs_per_machine`` if not set on pre-existing computer.
 
     If the ``localhost`` is created before ``prepare_computer`` is ever called, it is possible that the property
     ``default_mpiprocs_per_machine`` is not set. This would result the ``ShellJob`` validation to fail if the scheduler
     type has a job resource class that is a subclass of :class:`~aiida.schedulers.datastructures.NodeNumberJobResource`.
     """
+    aiida_profile.reset_storage()
+
     computer = generate_computer(scheduler_type=scheduler_type)
     computer.set_default_mpiprocs_per_machine(None)
     assert computer.get_default_mpiprocs_per_machine() is None


### PR DESCRIPTION
The new fixtures allow to configure a profile with `aiida_profile` with
a storage backend that doesn't require PostgreSQL but uses the
`core.sqlite_dos` plugin instead. The fixture by default also doesn't
configure to use RabbitMQ as the broker, however, the tests in
`aiida-shell` submit to the daemon which requires a broker. Therefore
`aiida_profile` is overridden to configure RabbitMQ`.