### PR TITLE
`ShellJob`: Add `metadata.options.output_filename` to retrieve list

### DIFF
--- a/src/aiida_shell/calculations/shell.py
+++ b/src/aiida_shell/calculations/shell.py
@@ -277,10 +277,14 @@ class ShellJob(CalcJob):
         arguments = (inputs.get('arguments', None) or List()).get_list()
         outputs = (inputs.get('outputs', None) or List()).get_list()
         filename_stdin = inputs['metadata']['options'].get('filename_stdin', None)
-        retrieve_list = (
-            outputs + list(self.DEFAULT_RETRIEVED_TEMPORARY) + (self.node.get_option('additional_retrieve') or [])
-        )
+        filename_stdout = inputs['metadata']['options'].get('output_filename', None)
+        default_retrieved_temporary = list(self.DEFAULT_RETRIEVED_TEMPORARY)
 
+        if filename_stdout:
+            default_retrieved_temporary.remove(self.FILENAME_STDOUT)
+            default_retrieved_temporary.append(filename_stdout)
+
+        retrieve_list = outputs + default_retrieved_temporary + (self.node.get_option('additional_retrieve') or [])
         processed_arguments = self.process_arguments_and_nodes(dirpath, nodes, filenames, arguments)
 
         # If an explicit filename for the stdin file descriptor is specified it should not be part of the command line

--- a/tests/calculations/test_shell.py
+++ b/tests/calculations/test_shell.py
@@ -222,6 +222,18 @@ def test_arguments_files_filenames(generate_calc_job, generate_code):
     assert code_info.cmdline_params == ['custom_filename']
 
 
+def test_output_filename(generate_calc_job, generate_code, file_regression):
+    """Test the ``metadata.options.output_filename`` input."""
+    output_filename = 'custom_stdout'
+    inputs = {
+        'code': generate_code('echo'),
+        'arguments': 'test',
+        'metadata': {'options': {'output_filename': output_filename}},
+    }
+    tmp_path, calc_info = generate_calc_job('core.shell', inputs, presubmit=True)
+    assert output_filename in calc_info.retrieve_temporary_list
+
+
 def test_filename_stdin(generate_calc_job, generate_code, file_regression):
     """Test the ``metadata.options.filename_stdin`` input."""
     inputs = {


### PR DESCRIPTION
Fixes #94 

The `metadata.options.output_filename` is defined by the `CalcJob` base class, and so is inherited by the `ShellJob`. The `ShellParser` plugin actually correctly deals with this case, however, the `ShellJob` only partially so. It did actually redirect stdout to this custom output file, however, it did not instruct for the custom output file to be retrieved, causing the `ERROR_OUTPUT_STDOUT_MISSING` to be returned.

The bug is fixed by replacing the default stdout filename in the `retrieve_temporary_list` with the custom `output_filename`.