### PR TITLE
Improve error message of commands consisting of multiple arguments

### DIFF
--- a/src/aiida_shell/launch.py
+++ b/src/aiida_shell/launch.py
@@ -128,7 +128,7 @@ def prepare_code(command: str, computer: Computer | None = None, resolve_command
 
         if resolve_command:
             with computer.get_transport() as transport:
-                status, stdout, stderr = transport.exec_command_wait(f'which {command}')
+                status, stdout, stderr = transport.exec_command_wait(f'which "{command}"')
                 executable = stdout.strip()
 
                 if status != 0:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -47,6 +47,15 @@ def test_error_command_failed():
     assert node.exit_status == ShellJob.exit_codes.ERROR_COMMAND_FAILED.status
 
 
+def test_multi_command_raise():
+    """Test :func:`aiida_shell.launch_shell_job` raises if ``command`` is passed with arguments.
+
+    Tests if the command is correctly resolved and raises an error message.
+    """
+    with pytest.raises(ValueError, match=r'failed to determine the absolute path of the command on the computer.*'):
+        launch_shell_job('git diff')
+
+
 def test_default():
     """Test :func:`aiida_shell.launch_shell_job` with default arguments."""
     results, node = launch_shell_job('date')


### PR DESCRIPTION
Commands like `git diff`, `verdi status` or `python script.py` will fail with different opaque error messages. We add a check that the command consists only out of one argument to give the user a clearer error message.