### PR TITLE
Devops: Add explicit `sphinx.configuration` key to RTD conf

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,5 @@ python:
 
 sphinx:
   builder: html
+  configuration: docs/source/conf.py
   fail_on_warning: true


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/