### PR TITLE
🔧 `ci`: fix CI rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:latest
+        image: rabbitmq:3.8.14-management
         ports:
         - 5672:5672
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.11.0
+  rev: v2.16.0
   hooks:
   - id: pretty-format-toml
     args: [--autofix]

--- a/src/aiida_shell/launch.py
+++ b/src/aiida_shell/launch.py
@@ -194,7 +194,7 @@ def prepare_code(command: str, computer: Computer | None = None, resolve_command
         else:
             executable = command
 
-        code = ShellCode(  # type: ignore[assignment]
+        code = ShellCode(
             label=command, computer=computer, filepath_executable=executable, default_calc_job_plugin='core.shell'
         ).store()
 


### PR DESCRIPTION
Surfaced by occuring unrelated CI failures on #116.

Appearing here after empty commit `54506ef`:
<img width="789" height="261" alt="image" src="https://github.com/user-attachments/assets/79cb2e50-292a-421a-83c5-04d494f0d3c1" />

Will squash-merge to obliterate the initial empty commit once approved 💥 